### PR TITLE
modify nasher.cfg to allow for 'slim' module installation

### DIFF
--- a/nasher.cfg
+++ b/nasher.cfg
@@ -15,3 +15,8 @@ include = "src/**/*.{nss,json}"
 name = "mod"
 file = "and_the_Wailing_Death.mod"
 description = ""
+
+[Target]
+name = "slim"
+file = "and_the_Wailing_Death.mod"
+filter = "*.{nss,ndb,gic}"


### PR DESCRIPTION
Modify the nasher.cfg file with new target `slim` to allow for contributors who don't use the toolset's code editor to modify the module with the toolset while simultaneously modifying scripts with an external editor.  Filtering `.nss` files will prevent modified external scripts from being overwritten when the module is unpacked by nasher.  This new target will not affect any current scripts used to pack/unpack/run the module and can only be used when specifically called.