### PR TITLE
fix dm entanglement vfx

### DIFF
--- a/src/nss/on_client_ent.nss
+++ b/src/nss/on_client_ent.nss
@@ -33,8 +33,21 @@ void main()
     }
 
     string sType = "player";
-
     string sMessage = PlayerDetailedName(oPC)+" has entered the game as a "+sType;
+
+    // Remove DM entangle effects
+    if (GetIsDM(oPC))
+    {
+        effect e = GetFirstEffect(oPC);
+        while (GetIsEffectValid(e))
+        {
+            if (GetEffectType(e) == EFFECT_TYPE_VISUALEFFECT &&
+                GetEffectInteger(e, 0) == VFX_DUR_ENTANGLE)
+                RemoveEffect(oPC, e);
+            
+            e = GetNextEffect(oPC);
+        }
+    }
 
     // Map Pins
     MapPin_LoadPCMapPins(oPC);


### PR DESCRIPTION
"Fix" for DM entanglement vfx.  Still can't find its source, so we'll just remove it on login if the player's a DM.  The VFX is applied twice, so all effects have to be looped and can't stop on the first find.