### PR TITLE
Added _ to start of Great Graveyard Tag name so no skybox is added by area_init script. This re-enables fog.

### DIFF
--- a/src/are/beg_grave.are.json
+++ b/src/are/beg_grave.are.json
@@ -148,7 +148,7 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "beg_grave"
+    "value": "_beg_grave"
   },
   "Tile_List": {
     "type": "list",


### PR DESCRIPTION
Tossing this out there, accept or reject.