### PR TITLE
Minor fixes, merchant changes

### DIFF
--- a/linux_run_server.sh
+++ b/linux_run_server.sh
@@ -31,7 +31,7 @@ cp config/common.env server/config/common.env
 cp settings.tml server/settings.tml
 cp database/spawns.sqlite3 server/database/spawns.sqlite3
 cp database/treasures.sqlite3 server/database/treasures.sqlite3
-cp database/treasures.sqlite3 server/database/randspellbooks.sqlite3
+cp database/randspellbooks.sqlite3 server/database/randspellbooks.sqlite3
 cp -r override/. server/override
 
 cp server/env/env.2da server/override/env.2da

--- a/src/git/bandit_cave.git.json
+++ b/src/git/bandit_cave.git.json
@@ -4643,6 +4643,26 @@
           "type": "resref",
           "value": "venkt"
         },
+        "VarTable": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 0,
+              "Name": {
+                "type": "cexostring",
+                "value": "semiboss"
+              },
+              "Type": {
+                "type": "dword",
+                "value": 1
+              },
+              "Value": {
+                "type": "int",
+                "value": 1
+              }
+            }
+          ]
+        },
         "WalkRate": {
           "type": "int",
           "value": 7
@@ -19533,7 +19553,7 @@
         },
         "Value": {
           "type": "int",
-          "value": 20
+          "value": 15
         }
       },
       {

--- a/src/git/nw_eastroad.git.json
+++ b/src/git/nw_eastroad.git.json
@@ -61293,7 +61293,7 @@
           "id": 14815,
           "type": "cexolocstring",
           "value": {
-            "0": "Neverwinter Rural"
+            "0": "Neverwinter North Gate"
           }
         },
         "MapNoteEnabled": {

--- a/src/git/nw_northroad.git.json
+++ b/src/git/nw_northroad.git.json
@@ -68770,7 +68770,7 @@
           "id": 14815,
           "type": "cexolocstring",
           "value": {
-            "0": "Neverwinter Rural"
+            "0": "Neverwinter North Gate"
           }
         },
         "MapNoteEnabled": {

--- a/src/git/valley_layenne.git.json
+++ b/src/git/valley_layenne.git.json
@@ -16720,1178 +16720,6 @@
         "__struct_id": 4,
         "Appearance_Type": {
           "type": "word",
-          "value": 92
-        },
-        "BodyBag": {
-          "type": "byte",
-          "value": 0
-        },
-        "Cha": {
-          "type": "byte",
-          "value": 3
-        },
-        "ChallengeRating": {
-          "type": "float",
-          "value": 13.0
-        },
-        "ClassList": {
-          "type": "list",
-          "value": [
-            {
-              "__struct_id": 2,
-              "Class": {
-                "type": "int",
-                "value": 13
-              },
-              "ClassLevel": {
-                "type": "short",
-                "value": 14
-              }
-            }
-          ]
-        },
-        "Con": {
-          "type": "byte",
-          "value": 10
-        },
-        "Conversation": {
-          "type": "resref",
-          "value": ""
-        },
-        "CRAdjust": {
-          "type": "int",
-          "value": 0
-        },
-        "CurrentHitPoints": {
-          "type": "short",
-          "value": 120
-        },
-        "DecayTime": {
-          "type": "dword",
-          "value": 5000
-        },
-        "Deity": {
-          "type": "cexostring",
-          "value": ""
-        },
-        "Description": {
-          "id": 12577,
-          "type": "cexolocstring",
-          "value": {}
-        },
-        "Dex": {
-          "type": "byte",
-          "value": 9
-        },
-        "Disarmable": {
-          "type": "byte",
-          "value": 0
-        },
-        "Equip_ItemList": {
-          "type": "list",
-          "value": [
-            {
-              "__struct_id": 65536,
-              "AddCost": {
-                "type": "dword",
-                "value": 0
-              },
-              "BaseItem": {
-                "type": "int",
-                "value": 71
-              },
-              "Charges": {
-                "type": "byte",
-                "value": 0
-              },
-              "Cost": {
-                "type": "dword",
-                "value": 8000
-              },
-              "Cursed": {
-                "type": "byte",
-                "value": 0
-              },
-              "DescIdentified": {
-                "type": "cexolocstring",
-                "value": {}
-              },
-              "Description": {
-                "type": "cexolocstring",
-                "value": {}
-              },
-              "Identified": {
-                "type": "byte",
-                "value": 0
-              },
-              "LocalizedName": {
-                "id": 13226,
-                "type": "cexolocstring",
-                "value": {}
-              },
-              "ModelPart1": {
-                "type": "byte",
-                "value": 1
-              },
-              "Plot": {
-                "type": "byte",
-                "value": 0
-              },
-              "PropertiesList": {
-                "type": "list",
-                "value": [
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 19
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 29
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 77
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 0
-                    }
-                  }
-                ]
-              },
-              "StackSize": {
-                "type": "word",
-                "value": 1
-              },
-              "Stolen": {
-                "type": "byte",
-                "value": 0
-              },
-              "Tag": {
-                "type": "cexostring",
-                "value": "NW_IT_CREWPB017"
-              },
-              "TemplateResRef": {
-                "type": "resref",
-                "value": "nw_it_crewpb017"
-              },
-              "XOrientation": {
-                "type": "float",
-                "value": 0.0
-              },
-              "XPosition": {
-                "type": "float",
-                "value": -1.0
-              },
-              "YOrientation": {
-                "type": "float",
-                "value": 1.0
-              },
-              "YPosition": {
-                "type": "float",
-                "value": -1.0
-              },
-              "ZPosition": {
-                "type": "float",
-                "value": -1.0
-              }
-            },
-            {
-              "__struct_id": 131072,
-              "AddCost": {
-                "type": "dword",
-                "value": 0
-              },
-              "BaseItem": {
-                "type": "int",
-                "value": 73
-              },
-              "Charges": {
-                "type": "byte",
-                "value": 0
-              },
-              "Cost": {
-                "type": "dword",
-                "value": 6498000
-              },
-              "Cursed": {
-                "type": "byte",
-                "value": 0
-              },
-              "DescIdentified": {
-                "type": "cexolocstring",
-                "value": {}
-              },
-              "Description": {
-                "type": "cexolocstring",
-                "value": {}
-              },
-              "Identified": {
-                "type": "byte",
-                "value": 0
-              },
-              "LocalizedName": {
-                "id": 13152,
-                "type": "cexolocstring",
-                "value": {}
-              },
-              "ModelPart1": {
-                "type": "byte",
-                "value": 1
-              },
-              "Plot": {
-                "type": "byte",
-                "value": 0
-              },
-              "PropertiesList": {
-                "type": "list",
-                "value": [
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 6
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 5
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 22
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 0
-                    }
-                  },
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 6
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 1
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 22
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 1
-                    }
-                  },
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 4
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 24
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 6
-                    }
-                  },
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 0
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 37
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 8
-                    }
-                  },
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 0
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 37
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 9
-                    }
-                  },
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 0
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 37
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 4
-                    }
-                  },
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 0
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 37
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 1
-                    }
-                  },
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 0
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 37
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 2
-                    }
-                  },
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 0
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 37
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 7
-                    }
-                  },
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 0
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 37
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 3
-                    }
-                  },
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 0
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 37
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 0
-                    }
-                  },
-                  {
-                    "__struct_id": 0,
-                    "ChanceAppear": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "CostTable": {
-                      "type": "byte",
-                      "value": 23
-                    },
-                    "CostValue": {
-                      "type": "word",
-                      "value": 9
-                    },
-                    "Param1": {
-                      "type": "byte",
-                      "value": 255
-                    },
-                    "Param1Value": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "PropertyName": {
-                      "type": "word",
-                      "value": 78
-                    },
-                    "Subtype": {
-                      "type": "word",
-                      "value": 0
-                    }
-                  }
-                ]
-              },
-              "StackSize": {
-                "type": "word",
-                "value": 1
-              },
-              "Stolen": {
-                "type": "byte",
-                "value": 0
-              },
-              "Tag": {
-                "type": "cexostring",
-                "value": "NW_IT_CREITEMCO5"
-              },
-              "TemplateResRef": {
-                "type": "resref",
-                "value": "stonegolemhide"
-              },
-              "XOrientation": {
-                "type": "float",
-                "value": 0.0
-              },
-              "XPosition": {
-                "type": "float",
-                "value": -1.0
-              },
-              "YOrientation": {
-                "type": "float",
-                "value": 1.0
-              },
-              "YPosition": {
-                "type": "float",
-                "value": -1.0
-              },
-              "ZPosition": {
-                "type": "float",
-                "value": -1.0
-              }
-            }
-          ]
-        },
-        "FactionID": {
-          "type": "word",
-          "value": 1
-        },
-        "FeatList": {
-          "type": "list",
-          "value": [
-            {
-              "__struct_id": 1,
-              "Feat": {
-                "type": "word",
-                "value": 228
-              }
-            },
-            {
-              "__struct_id": 1,
-              "Feat": {
-                "type": "word",
-                "value": 289
-              }
-            }
-          ]
-        },
-        "FirstName": {
-          "id": 12578,
-          "type": "cexolocstring",
-          "value": {}
-        },
-        "fortbonus": {
-          "type": "short",
-          "value": 0
-        },
-        "Gender": {
-          "type": "byte",
-          "value": 4
-        },
-        "GoodEvil": {
-          "type": "byte",
-          "value": 50
-        },
-        "HitPoints": {
-          "type": "short",
-          "value": 120
-        },
-        "Int": {
-          "type": "byte",
-          "value": 3
-        },
-        "Interruptable": {
-          "type": "byte",
-          "value": 1
-        },
-        "IsImmortal": {
-          "type": "byte",
-          "value": 0
-        },
-        "IsPC": {
-          "type": "byte",
-          "value": 0
-        },
-        "LastName": {
-          "type": "cexolocstring",
-          "value": {}
-        },
-        "LawfulChaotic": {
-          "type": "byte",
-          "value": 50
-        },
-        "Lootable": {
-          "type": "byte",
-          "value": 0
-        },
-        "MaxHitPoints": {
-          "type": "short",
-          "value": 120
-        },
-        "NaturalAC": {
-          "type": "byte",
-          "value": 15
-        },
-        "NoPermDeath": {
-          "type": "byte",
-          "value": 0
-        },
-        "PerceptionRange": {
-          "type": "byte",
-          "value": 11
-        },
-        "Phenotype": {
-          "type": "int",
-          "value": 0
-        },
-        "Plot": {
-          "type": "byte",
-          "value": 0
-        },
-        "PortraitId": {
-          "type": "word",
-          "value": 230
-        },
-        "Race": {
-          "type": "byte",
-          "value": 10
-        },
-        "refbonus": {
-          "type": "short",
-          "value": 0
-        },
-        "ScriptAttacked": {
-          "type": "resref",
-          "value": "ai_onattacked"
-        },
-        "ScriptDamaged": {
-          "type": "resref",
-          "value": "ai_ondamaged"
-        },
-        "ScriptDeath": {
-          "type": "resref",
-          "value": "ai_ondeath"
-        },
-        "ScriptDialogue": {
-          "type": "resref",
-          "value": "ai_onconverse"
-        },
-        "ScriptDisturbed": {
-          "type": "resref",
-          "value": "ai_ondisturb"
-        },
-        "ScriptEndRound": {
-          "type": "resref",
-          "value": "ai_oncombrnd"
-        },
-        "ScriptHeartbeat": {
-          "type": "resref",
-          "value": "ai_onheartb"
-        },
-        "ScriptOnBlocked": {
-          "type": "resref",
-          "value": "ai_onblocked"
-        },
-        "ScriptOnNotice": {
-          "type": "resref",
-          "value": "ai_onpercep"
-        },
-        "ScriptRested": {
-          "type": "resref",
-          "value": "ai_onrest"
-        },
-        "ScriptSpawn": {
-          "type": "resref",
-          "value": "ai_onspawn"
-        },
-        "ScriptSpellAt": {
-          "type": "resref",
-          "value": "ai_onspellcast"
-        },
-        "ScriptUserDefine": {
-          "type": "resref",
-          "value": "ai_onuserdef"
-        },
-        "SkillList": {
-          "type": "list",
-          "value": [
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Rank": {
-                "type": "byte",
-                "value": 0
-              }
-            }
-          ]
-        },
-        "SoundSetFile": {
-          "type": "word",
-          "value": 50
-        },
-        "SpecAbilityList": {
-          "type": "list",
-          "value": [
-            {
-              "__struct_id": 4,
-              "Spell": {
-                "type": "word",
-                "value": 226
-              },
-              "SpellCasterLevel": {
-                "type": "byte",
-                "value": 7
-              },
-              "SpellFlags": {
-                "type": "byte",
-                "value": 1
-              }
-            },
-            {
-              "__struct_id": 4,
-              "Spell": {
-                "type": "word",
-                "value": 226
-              },
-              "SpellCasterLevel": {
-                "type": "byte",
-                "value": 7
-              },
-              "SpellFlags": {
-                "type": "byte",
-                "value": 1
-              }
-            },
-            {
-              "__struct_id": 4,
-              "Spell": {
-                "type": "word",
-                "value": 226
-              },
-              "SpellCasterLevel": {
-                "type": "byte",
-                "value": 7
-              },
-              "SpellFlags": {
-                "type": "byte",
-                "value": 1
-              }
-            }
-          ]
-        },
-        "StartingPackage": {
-          "type": "byte",
-          "value": 0
-        },
-        "Str": {
-          "type": "byte",
-          "value": 25
-        },
-        "Subrace": {
-          "type": "cexostring",
-          "value": ""
-        },
-        "Tag": {
-          "type": "cexostring",
-          "value": "NW_GOLSTONE"
-        },
-        "Tail_New": {
-          "type": "dword",
-          "value": 0
-        },
-        "TemplateList": {
-          "type": "list",
-          "value": []
-        },
-        "TemplateResRef": {
-          "type": "resref",
-          "value": "golem_stone"
-        },
-        "VarTable": {
-          "type": "list",
-          "value": [
-            {
-              "__struct_id": 0,
-              "Name": {
-                "type": "cexostring",
-                "value": "semiboss"
-              },
-              "Type": {
-                "type": "dword",
-                "value": 1
-              },
-              "Value": {
-                "type": "int",
-                "value": 1
-              }
-            },
-            {
-              "__struct_id": 0,
-              "Name": {
-                "type": "cexostring",
-                "value": "no_wander"
-              },
-              "Type": {
-                "type": "dword",
-                "value": 1
-              },
-              "Value": {
-                "type": "int",
-                "value": 1
-              }
-            }
-          ]
-        },
-        "WalkRate": {
-          "type": "int",
-          "value": 7
-        },
-        "willbonus": {
-          "type": "short",
-          "value": 0
-        },
-        "Wings_New": {
-          "type": "dword",
-          "value": 0
-        },
-        "Wis": {
-          "type": "byte",
-          "value": 11
-        },
-        "XOrientation": {
-          "type": "float",
-          "value": 0.0
-        },
-        "XPosition": {
-          "type": "float",
-          "value": 105.1466
-        },
-        "YOrientation": {
-          "type": "float",
-          "value": 1.0
-        },
-        "YPosition": {
-          "type": "float",
-          "value": 71.6148
-        },
-        "ZPosition": {
-          "type": "float",
-          "value": 0.2
-        }
-      },
-      {
-        "__struct_id": 4,
-        "Appearance_Type": {
-          "type": "word",
           "value": 89
         },
         "BodyBag": {
@@ -19985,6 +18813,1150 @@
         "ZPosition": {
           "type": "float",
           "value": 0.0
+        }
+      },
+      {
+        "__struct_id": 4,
+        "Appearance_Type": {
+          "type": "word",
+          "value": 92
+        },
+        "BodyBag": {
+          "type": "byte",
+          "value": 0
+        },
+        "Cha": {
+          "type": "byte",
+          "value": 3
+        },
+        "ChallengeRating": {
+          "type": "float",
+          "value": 11.0
+        },
+        "ClassList": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 2,
+              "Class": {
+                "type": "int",
+                "value": 13
+              },
+              "ClassLevel": {
+                "type": "short",
+                "value": 12
+              }
+            }
+          ]
+        },
+        "Con": {
+          "type": "byte",
+          "value": 10
+        },
+        "Conversation": {
+          "type": "resref",
+          "value": ""
+        },
+        "CRAdjust": {
+          "type": "int",
+          "value": 0
+        },
+        "CurrentHitPoints": {
+          "type": "short",
+          "value": 100
+        },
+        "DecayTime": {
+          "type": "dword",
+          "value": 5000
+        },
+        "Deity": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "Description": {
+          "id": 12577,
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "Dex": {
+          "type": "byte",
+          "value": 9
+        },
+        "Disarmable": {
+          "type": "byte",
+          "value": 0
+        },
+        "Equip_ItemList": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 65536,
+              "AddCost": {
+                "type": "dword",
+                "value": 0
+              },
+              "BaseItem": {
+                "type": "int",
+                "value": 71
+              },
+              "Charges": {
+                "type": "byte",
+                "value": 0
+              },
+              "Cost": {
+                "type": "dword",
+                "value": 8000
+              },
+              "Cursed": {
+                "type": "byte",
+                "value": 0
+              },
+              "DescIdentified": {
+                "type": "cexolocstring",
+                "value": {}
+              },
+              "Description": {
+                "type": "cexolocstring",
+                "value": {}
+              },
+              "Identified": {
+                "type": "byte",
+                "value": 0
+              },
+              "LocalizedName": {
+                "id": 13226,
+                "type": "cexolocstring",
+                "value": {}
+              },
+              "ModelPart1": {
+                "type": "byte",
+                "value": 1
+              },
+              "Plot": {
+                "type": "byte",
+                "value": 0
+              },
+              "PropertiesList": {
+                "type": "list",
+                "value": [
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 19
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 29
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 77
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 0
+                    }
+                  }
+                ]
+              },
+              "StackSize": {
+                "type": "word",
+                "value": 1
+              },
+              "Stolen": {
+                "type": "byte",
+                "value": 0
+              },
+              "Tag": {
+                "type": "cexostring",
+                "value": "NW_IT_CREWPB017"
+              },
+              "TemplateResRef": {
+                "type": "resref",
+                "value": "nw_it_crewpb017"
+              },
+              "XOrientation": {
+                "type": "float",
+                "value": 0.0
+              },
+              "XPosition": {
+                "type": "float",
+                "value": -1.0
+              },
+              "YOrientation": {
+                "type": "float",
+                "value": 1.0
+              },
+              "YPosition": {
+                "type": "float",
+                "value": -1.0
+              },
+              "ZPosition": {
+                "type": "float",
+                "value": -1.0
+              }
+            },
+            {
+              "__struct_id": 131072,
+              "AddCost": {
+                "type": "dword",
+                "value": 0
+              },
+              "BaseItem": {
+                "type": "int",
+                "value": 73
+              },
+              "Charges": {
+                "type": "byte",
+                "value": 0
+              },
+              "Cost": {
+                "type": "dword",
+                "value": 6498000
+              },
+              "Cursed": {
+                "type": "byte",
+                "value": 0
+              },
+              "DescIdentified": {
+                "type": "cexolocstring",
+                "value": {}
+              },
+              "Description": {
+                "type": "cexolocstring",
+                "value": {}
+              },
+              "Identified": {
+                "type": "byte",
+                "value": 0
+              },
+              "LocalizedName": {
+                "id": 13152,
+                "type": "cexolocstring",
+                "value": {}
+              },
+              "ModelPart1": {
+                "type": "byte",
+                "value": 1
+              },
+              "Plot": {
+                "type": "byte",
+                "value": 0
+              },
+              "PropertiesList": {
+                "type": "list",
+                "value": [
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 6
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 5
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 0
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 22
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 0
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 6
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 1
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 22
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 1
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 22
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 4
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 0
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 24
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 6
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 0
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 0
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 37
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 8
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 0
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 0
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 37
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 9
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 0
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 0
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 37
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 4
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 0
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 0
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 37
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 1
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 0
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 0
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 37
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 2
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 0
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 0
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 37
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 7
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 0
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 0
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 37
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 3
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 0
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 0
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 0
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 37
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 0
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "ChanceAppear": {
+                      "type": "byte",
+                      "value": 100
+                    },
+                    "CostTable": {
+                      "type": "byte",
+                      "value": 23
+                    },
+                    "CostValue": {
+                      "type": "word",
+                      "value": 9
+                    },
+                    "Param1": {
+                      "type": "byte",
+                      "value": 255
+                    },
+                    "Param1Value": {
+                      "type": "byte",
+                      "value": 0
+                    },
+                    "PropertyName": {
+                      "type": "word",
+                      "value": 78
+                    },
+                    "Subtype": {
+                      "type": "word",
+                      "value": 0
+                    }
+                  }
+                ]
+              },
+              "StackSize": {
+                "type": "word",
+                "value": 1
+              },
+              "Stolen": {
+                "type": "byte",
+                "value": 0
+              },
+              "Tag": {
+                "type": "cexostring",
+                "value": "NW_IT_CREITEMCO5"
+              },
+              "TemplateResRef": {
+                "type": "resref",
+                "value": "stonegolemhide"
+              },
+              "XOrientation": {
+                "type": "float",
+                "value": 0.0
+              },
+              "XPosition": {
+                "type": "float",
+                "value": -1.0
+              },
+              "YOrientation": {
+                "type": "float",
+                "value": 1.0
+              },
+              "YPosition": {
+                "type": "float",
+                "value": -1.0
+              },
+              "ZPosition": {
+                "type": "float",
+                "value": -1.0
+              }
+            }
+          ]
+        },
+        "FactionID": {
+          "type": "word",
+          "value": 1
+        },
+        "FeatList": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 228
+              }
+            },
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 289
+              }
+            }
+          ]
+        },
+        "FirstName": {
+          "id": 12578,
+          "type": "cexolocstring",
+          "value": {
+            "0": "Lesser Stone Golem"
+          }
+        },
+        "fortbonus": {
+          "type": "short",
+          "value": 0
+        },
+        "Gender": {
+          "type": "byte",
+          "value": 4
+        },
+        "GoodEvil": {
+          "type": "byte",
+          "value": 50
+        },
+        "HitPoints": {
+          "type": "short",
+          "value": 100
+        },
+        "Int": {
+          "type": "byte",
+          "value": 3
+        },
+        "Interruptable": {
+          "type": "byte",
+          "value": 1
+        },
+        "IsImmortal": {
+          "type": "byte",
+          "value": 0
+        },
+        "IsPC": {
+          "type": "byte",
+          "value": 0
+        },
+        "LastName": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "LawfulChaotic": {
+          "type": "byte",
+          "value": 50
+        },
+        "Lootable": {
+          "type": "byte",
+          "value": 0
+        },
+        "MaxHitPoints": {
+          "type": "short",
+          "value": 100
+        },
+        "NaturalAC": {
+          "type": "byte",
+          "value": 12
+        },
+        "NoPermDeath": {
+          "type": "byte",
+          "value": 0
+        },
+        "PerceptionRange": {
+          "type": "byte",
+          "value": 11
+        },
+        "Phenotype": {
+          "type": "int",
+          "value": 0
+        },
+        "Plot": {
+          "type": "byte",
+          "value": 0
+        },
+        "PortraitId": {
+          "type": "word",
+          "value": 230
+        },
+        "Race": {
+          "type": "byte",
+          "value": 10
+        },
+        "refbonus": {
+          "type": "short",
+          "value": 0
+        },
+        "ScriptAttacked": {
+          "type": "resref",
+          "value": "ai_onattacked"
+        },
+        "ScriptDamaged": {
+          "type": "resref",
+          "value": "ai_ondamaged"
+        },
+        "ScriptDeath": {
+          "type": "resref",
+          "value": "ai_ondeath"
+        },
+        "ScriptDialogue": {
+          "type": "resref",
+          "value": "ai_onconverse"
+        },
+        "ScriptDisturbed": {
+          "type": "resref",
+          "value": "ai_ondisturb"
+        },
+        "ScriptEndRound": {
+          "type": "resref",
+          "value": "ai_oncombrnd"
+        },
+        "ScriptHeartbeat": {
+          "type": "resref",
+          "value": "ai_onheartb"
+        },
+        "ScriptOnBlocked": {
+          "type": "resref",
+          "value": "ai_onblocked"
+        },
+        "ScriptOnNotice": {
+          "type": "resref",
+          "value": "ai_onpercep"
+        },
+        "ScriptRested": {
+          "type": "resref",
+          "value": "ai_onrest"
+        },
+        "ScriptSpawn": {
+          "type": "resref",
+          "value": "ai_onspawn"
+        },
+        "ScriptSpellAt": {
+          "type": "resref",
+          "value": "ai_onspellcast"
+        },
+        "ScriptUserDefine": {
+          "type": "resref",
+          "value": "ai_onuserdef"
+        },
+        "SkillList": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            }
+          ]
+        },
+        "SoundSetFile": {
+          "type": "word",
+          "value": 50
+        },
+        "SpecAbilityList": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 4,
+              "Spell": {
+                "type": "word",
+                "value": 226
+              },
+              "SpellCasterLevel": {
+                "type": "byte",
+                "value": 7
+              },
+              "SpellFlags": {
+                "type": "byte",
+                "value": 1
+              }
+            }
+          ]
+        },
+        "StartingPackage": {
+          "type": "byte",
+          "value": 0
+        },
+        "Str": {
+          "type": "byte",
+          "value": 21
+        },
+        "Subrace": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "NW_GOLSTONE"
+        },
+        "Tail_New": {
+          "type": "dword",
+          "value": 0
+        },
+        "TemplateList": {
+          "type": "list",
+          "value": []
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "lesser_gol_stone"
+        },
+        "VarTable": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 0,
+              "Name": {
+                "type": "cexostring",
+                "value": "semiboss"
+              },
+              "Type": {
+                "type": "dword",
+                "value": 1
+              },
+              "Value": {
+                "type": "int",
+                "value": 1
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Name": {
+                "type": "cexostring",
+                "value": "no_wander"
+              },
+              "Type": {
+                "type": "dword",
+                "value": 1
+              },
+              "Value": {
+                "type": "int",
+                "value": 1
+              }
+            }
+          ]
+        },
+        "WalkRate": {
+          "type": "int",
+          "value": 7
+        },
+        "willbonus": {
+          "type": "short",
+          "value": 0
+        },
+        "Wings_New": {
+          "type": "dword",
+          "value": 0
+        },
+        "Wis": {
+          "type": "byte",
+          "value": 11
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": 0.0
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 104.5561
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": 1.0
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 72.2688
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 0.2
         }
       }
     ]
@@ -50215,7 +50187,7 @@
         },
         "Value": {
           "type": "int",
-          "value": 20
+          "value": 25
         }
       },
       {

--- a/src/itp/creaturepalcus.itp.json
+++ b/src/itp/creaturepalcus.itp.json
@@ -772,7 +772,7 @@
                     "__struct_id": 0,
                     "CR": {
                       "type": "float",
-                      "value": 6.0
+                      "value": 5.0
                     },
                     "FACTION": {
                       "type": "cexostring",

--- a/src/itp/creaturepalcus.itp.json
+++ b/src/itp/creaturepalcus.itp.json
@@ -4637,6 +4637,25 @@
                     "__struct_id": 0,
                     "CR": {
                       "type": "float",
+                      "value": 11.0
+                    },
+                    "FACTION": {
+                      "type": "cexostring",
+                      "value": "Hostile"
+                    },
+                    "NAME": {
+                      "type": "cexostring",
+                      "value": "Lesser Stone Golem"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "lesser_gol_stone"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "CR": {
+                      "type": "float",
                       "value": 6.0
                     },
                     "FACTION": {

--- a/src/nss/inc_loot.nss
+++ b/src/nss/inc_loot.nss
@@ -247,15 +247,14 @@ object GenerateTierItem(int iCR, int iAreaCR, object oContainer, string sType = 
 // Given no type, generate a random one.
     if (sType == "")
     {
-        switch(Random(7))
+        switch(Random(6))
         {
            case 0: sType = "Misc"; break;
            case 1: sType = "Scrolls"; break;
            case 2: sType = "Weapon"; break;
            case 3: sType = "Armor"; break;
-           case 4: sType = "Range"; break;
-           case 5: sType = "Apparel"; break;
-           case 6: sType = "Potions"; break;
+           case 4: sType = "Apparel"; break;
+           case 5: sType = "Potions"; break;
         }
     }
 

--- a/src/nss/inc_webhook.nss
+++ b/src/nss/inc_webhook.nss
@@ -92,11 +92,11 @@ string GetPartySizeString(object oPC)
         nNumNPCS += GetHenchmanCount(oPartyMember);
         oPartyMember = GetNextFactionMember(oPC);
     }
-    
-    string sOut = IntToString(nNumNPCS + nNumPCs);
+    string sOut = "0 NPCs";
+    //string sOut = IntToString(nNumNPCS + nNumPCs);
     if (nNumNPCS > 0)
     {
-        sOut += " (" + IntToString(nNumNPCS) + " NPC" + (nNumNPCS > 1 ? "s" : "") + ")";
+        sOut == IntToString(nNumNPCS) + " NPC" + (nNumNPCS > 1 ? "s" : "");
     }
     return sOut;
 }

--- a/src/nss/mer_branson.nss
+++ b/src/nss/mer_branson.nss
@@ -6,24 +6,29 @@ void main()
     int i;
     for (i = 0; i < nItems; i++)
     {
-        GenerateTierItem(9, 6, OBJECT_SELF);
+        GenerateTierItem(9, 8, OBJECT_SELF);
     }
+    
+    int bNonUnique;
 
     int nMax = d3(4);
     for (i = 0; i < nMax; i++)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "", 3, TRUE);
+        bNonUnique = d10() >= 3;
+        GenerateTierItem(0, 0, OBJECT_SELF, "", 3, bNonUnique);
     }
 
     nMax = d2(3);
     for (i = 0; i < nMax; i++)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "", 4, TRUE);
+        bNonUnique = d10() >= 3;
+        GenerateTierItem(0, 0, OBJECT_SELF, "", 4, bNonUnique);
     }
 
     nMax = d2();
     for (i = 0; i < nMax; i++)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "", 5, TRUE);
+        bNonUnique = d10() >= 3;
+        GenerateTierItem(0, 0, OBJECT_SELF, "", 5, bNonUnique);
     }
 }

--- a/src/nss/mer_camilla.nss
+++ b/src/nss/mer_camilla.nss
@@ -6,7 +6,7 @@ void main()
     int i;
     for (i = 0; i < nItems; i++)
     {
-        GenerateTierItem(6, 3, OBJECT_SELF);
+        GenerateTierItem(6, 5, OBJECT_SELF);
     }
 
     int nMax = d4(4);

--- a/src/nss/mer_durga.nss
+++ b/src/nss/mer_durga.nss
@@ -71,7 +71,9 @@ void main()
         {
             GenerateTierItem(0, 0, OBJECT_SELF, "Armor", 5, TRUE);
         }
-
+    }
+    if (d2() == 1)
+    {
         nMax = d2();
         for (i = 0; i < nMax; i++)
         {

--- a/src/nss/mer_edario.nss
+++ b/src/nss/mer_edario.nss
@@ -60,15 +60,20 @@ void main()
     }
 
 
-    nMax = d2();
-    for (i = 0; i < nMax; i++)
+    if (d2() == 1)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "Armor", 5, TRUE);
+        nMax = d2();
+        for (i = 0; i < nMax; i++)
+        {
+            GenerateTierItem(0, 0, OBJECT_SELF, "Armor", 5, TRUE);
+        }
     }
-
-    nMax = d2();
-    for (i = 0; i < nMax; i++)
+    if (d2() == 1)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "Melee", 5, TRUE);
+        nMax = d2();
+        for (i = 0; i < nMax; i++)
+        {
+            GenerateTierItem(0, 0, OBJECT_SELF, "Melee", 5, TRUE);
+        }
     }
 }

--- a/src/nss/mer_elaith.nss
+++ b/src/nss/mer_elaith.nss
@@ -9,13 +9,13 @@ void main()
         GenerateTierItem(0, 0, OBJECT_SELF, "", 3, TRUE);
     }
 
-    nMax = d3(4);
+    nMax = d3(6);
     for (i = 0; i < nMax; i++)
     {
         GenerateTierItem(0, 0, OBJECT_SELF, "", 4, TRUE);
     }
 
-    nMax = d2(3);
+    nMax = d2();
     for (i = 0; i < nMax; i++)
     {
         GenerateTierItem(0, 0, OBJECT_SELF, "", 5, TRUE);

--- a/src/nss/mer_haljal.nss
+++ b/src/nss/mer_haljal.nss
@@ -55,39 +55,50 @@ void main()
     }
 
 
-    nMax = d2();
-    for (i = 0; i < nMax; i++)
+    if (d2() == 2)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "Armor", 5, TRUE);
+        nMax = d2();
+        for (i = 0; i < nMax; i++)
+        {
+            GenerateTierItem(0, 0, OBJECT_SELF, "Armor", 5, TRUE);
+        }
     }
 
-    nMax = d2();
-    for (i = 0; i < nMax; i++)
+    if (d2() == 2)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "Melee", 5, TRUE);
+        nMax = d2();
+        for (i = 0; i < nMax; i++)
+        {
+            GenerateTierItem(0, 0, OBJECT_SELF, "Melee", 5, TRUE);
+        }
     }
+    
+    int bNonUnique;
 
     int nItems = d6(10);
     for (i = 0; i < nItems; i++)
     {
-        GenerateTierItem(4, 10, OBJECT_SELF);
+        GenerateTierItem(6, 6, OBJECT_SELF);
     }
 
     nMax = d3(4);
     for (i = 0; i < nMax; i++)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "", 3, TRUE);
+        bNonUnique = d10() >= 3;
+        GenerateTierItem(0, 0, OBJECT_SELF, "", 3, bNonUnique);
     }
 
     nMax = d3(3);
     for (i = 0; i < nMax; i++)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "", 4, TRUE);
+        bNonUnique = d10() >= 3;
+        GenerateTierItem(0, 0, OBJECT_SELF, "", 4, bNonUnique);
     }
 
-    nMax = d2(2);
+    nMax = d2();
     for (i = 0; i < nMax; i++)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "", 5, TRUE);
+        bNonUnique = d10() >= 3;
+        GenerateTierItem(0, 0, OBJECT_SELF, "", 5, bNonUnique);
     }
 }

--- a/src/nss/mer_olgerd.nss
+++ b/src/nss/mer_olgerd.nss
@@ -4,26 +4,33 @@ void main()
 {
     int nItems = d20(20);
     int i;
+    int bAllowUnique;
+    
     for (i = 0; i < nItems; i++)
     {
-        GenerateTierItem(4, 10, OBJECT_SELF);
+        GenerateTierItem(4, 4, OBJECT_SELF);
     }
+
+    int bNonUnique;
 
     int nMax = d4(4);
     for (i = 0; i < nMax; i++)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "", 3, TRUE);
+        bNonUnique = d10() >= 3;
+        GenerateTierItem(0, 0, OBJECT_SELF, "", 3, bNonUnique);
     }
 
     nMax = d3(3);
     for (i = 0; i < nMax; i++)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "", 4, TRUE);
+        bNonUnique = d10() >= 3;
+        GenerateTierItem(0, 0, OBJECT_SELF, "", 4, bNonUnique);
     }
 
-    nMax = d2(2);
+    nMax = d2();
     for (i = 0; i < nMax; i++)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "", 5, TRUE);
+        bNonUnique = d10() >= 3;
+        GenerateTierItem(0, 0, OBJECT_SELF, "", 5, bNonUnique);
     }
 }

--- a/src/nss/mer_ravyn.nss
+++ b/src/nss/mer_ravyn.nss
@@ -8,22 +8,27 @@ void main()
     {
         GenerateTierItem(15, 12, OBJECT_SELF);
     }
+    
+    int bNonUnique;
 
     int nMax = d3(3);
     for (i = 0; i < nMax; i++)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "", 3, TRUE);
+        bNonUnique = d10() >= 3;
+        GenerateTierItem(0, 0, OBJECT_SELF, "", 3, bNonUnique);
     }
 
     nMax = d2(2);
     for (i = 0; i < nMax; i++)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "", 4, TRUE);
+        bNonUnique = d10() >= 3;
+        GenerateTierItem(0, 0, OBJECT_SELF, "", 4, bNonUnique);
     }
 
     nMax = d2();
     for (i = 0; i < nMax; i++)
     {
-        GenerateTierItem(0, 0, OBJECT_SELF, "", 5, TRUE);
+        bNonUnique = d10() >= 3;
+        GenerateTierItem(0, 0, OBJECT_SELF, "", 5, bNonUnique);
     }
 }

--- a/src/nss/mer_rizolvir.nss
+++ b/src/nss/mer_rizolvir.nss
@@ -55,13 +55,13 @@ void main()
         GenerateTierItem(0, 0, OBJECT_SELF, "Armor", 5, TRUE);
     }
 
-    nMax = d3();
+    nMax = d2();
     for (i = 0; i < nMax; i++)
     {
         GenerateTierItem(0, 0, OBJECT_SELF, "Melee", 5, TRUE);
     }
 
-    nMax = d3(2);
+    nMax = d3();
     for (i = 0; i < nMax; i++)
     {
         GenerateTierItem(0, 0, OBJECT_SELF, "Range", 5, TRUE);

--- a/src/utc/hakt.utc.json
+++ b/src/utc/hakt.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 6.0
+    "value": 5.0
   },
   "ClassList": {
     "type": "list",
@@ -27,7 +27,7 @@
         },
         "ClassLevel": {
           "type": "short",
-          "value": 6
+          "value": 5
         }
       }
     ]
@@ -50,7 +50,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 55
+    "value": 48
   },
   "DecayTime": {
     "type": "dword",
@@ -68,7 +68,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 13
+    "value": 14
   },
   "Disarmable": {
     "type": "byte",
@@ -146,13 +146,6 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 63
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
           "value": 26
         }
       },
@@ -168,13 +161,6 @@
         "Feat": {
           "type": "word",
           "value": 27
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 28
         }
       },
       {
@@ -234,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 55
+    "value": 48
   },
   "Int": {
     "type": "byte",
@@ -288,7 +274,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 73
+    "value": 63
   },
   "NaturalAC": {
     "type": "byte",
@@ -593,7 +579,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 18
+    "value": 17
   },
   "Subrace": {
     "type": "cexostring",

--- a/src/utc/lesser_gol_stone.utc.json
+++ b/src/utc/lesser_gol_stone.utc.json
@@ -2,7 +2,7 @@
   "__data_type": "UTC ",
   "Appearance_Type": {
     "type": "word",
-    "value": 24
+    "value": 92
   },
   "BodyBag": {
     "type": "byte",
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 10.0
+    "value": 11.0
   },
   "ClassList": {
     "type": "list",
@@ -46,11 +46,11 @@
   },
   "CRAdjust": {
     "type": "int",
-    "value": 1
+    "value": 0
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 66
+    "value": 100
   },
   "DecayTime": {
     "type": "dword",
@@ -61,10 +61,9 @@
     "value": ""
   },
   "Description": {
+    "id": 12577,
     "type": "cexolocstring",
-    "value": {
-      "0": "Created by demented wizards, Bone Golems are generally used to guard prized possessions. Their bodies are pieced together from various creatures, both humanoid and monster."
-    }
+    "value": {}
   },
   "Dex": {
     "type": "byte",
@@ -72,23 +71,23 @@
   },
   "Disarmable": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "Equip_ItemList": {
     "type": "list",
     "value": [
       {
-        "__struct_id": 16384,
+        "__struct_id": 65536,
         "EquippedRes": {
           "type": "resref",
-          "value": "nw_it_crewpsp005"
+          "value": "nw_it_crewpb017"
         }
       },
       {
         "__struct_id": 131072,
         "EquippedRes": {
           "type": "resref",
-          "value": "it_creitemco008"
+          "value": "stonegolemhide"
         }
       }
     ]
@@ -104,15 +103,23 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
+          "value": 228
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
           "value": 289
         }
       }
     ]
   },
   "FirstName": {
+    "id": 12578,
     "type": "cexolocstring",
     "value": {
-      "0": "Bone Golem"
+      "0": "Lesser Stone Golem"
     }
   },
   "fortbonus": {
@@ -121,7 +128,7 @@
   },
   "Gender": {
     "type": "byte",
-    "value": 0
+    "value": 4
   },
   "GoodEvil": {
     "type": "byte",
@@ -129,11 +136,11 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 66
+    "value": 100
   },
   "Int": {
     "type": "byte",
-    "value": 10
+    "value": 3
   },
   "Interruptable": {
     "type": "byte",
@@ -149,9 +156,7 @@
   },
   "LastName": {
     "type": "cexolocstring",
-    "value": {
-      "0": ""
-    }
+    "value": {}
   },
   "LawfulChaotic": {
     "type": "byte",
@@ -163,11 +168,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 66
+    "value": 100
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 0
+    "value": 12
   },
   "NoPermDeath": {
     "type": "byte",
@@ -191,7 +196,7 @@
   },
   "PortraitId": {
     "type": "word",
-    "value": 226
+    "value": 230
   },
   "Race": {
     "type": "byte",
@@ -330,7 +335,7 @@
         "__struct_id": 0,
         "Rank": {
           "type": "byte",
-          "value": 15
+          "value": 0
         }
       },
       {
@@ -456,19 +461,35 @@
   },
   "SoundSetFile": {
     "type": "word",
-    "value": 65535
+    "value": 50
   },
   "SpecAbilityList": {
     "type": "list",
-    "value": []
+    "value": [
+      {
+        "__struct_id": 4,
+        "Spell": {
+          "type": "word",
+          "value": 226
+        },
+        "SpellCasterLevel": {
+          "type": "byte",
+          "value": 7
+        },
+        "SpellFlags": {
+          "type": "byte",
+          "value": 1
+        }
+      }
+    ]
   },
   "StartingPackage": {
     "type": "byte",
-    "value": 75
+    "value": 0
   },
   "Str": {
     "type": "byte",
-    "value": 24
+    "value": 21
   },
   "Subrace": {
     "type": "cexostring",
@@ -476,7 +497,7 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "BoneGolem"
+    "value": "NW_GOLSTONE"
   },
   "Tail_New": {
     "type": "dword",
@@ -488,11 +509,46 @@
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "bonegolem"
+    "value": "lesser_gol_stone"
+  },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "semiboss"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "no_wander"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
   },
   "WalkRate": {
     "type": "int",
-    "value": 3
+    "value": 7
   },
   "willbonus": {
     "type": "short",

--- a/src/utc/venkt.utc.json
+++ b/src/utc/venkt.utc.json
@@ -934,6 +934,21 @@
           "type": "int",
           "value": 1
         }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "defeated_webhook"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
       }
     ]
   },

--- a/src/uti/keybag.uti.json
+++ b/src/uti/keybag.uti.json
@@ -67,37 +67,6 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 30
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 1
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 87
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
           "value": 3
         },
         "CostValue": {

--- a/src/utm/merchant10.utm.json
+++ b/src/utm/merchant10.utm.json
@@ -66,7 +66,7 @@
               "__struct_id": 0,
               "InventoryRes": {
                 "type": "resref",
-                "value": "armor1"
+                "value": "armor77"
               },
               "Repos_PosX": {
                 "type": "word",
@@ -81,26 +81,11 @@
               "__struct_id": 1,
               "InventoryRes": {
                 "type": "resref",
-                "value": "armor77"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 2
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 2,
-              "InventoryRes": {
-                "type": "resref",
                 "value": "armor76"
               },
               "Repos_PosX": {
                 "type": "word",
-                "value": 4
+                "value": 2
               },
               "Repos_Posy": {
                 "type": "word",
@@ -119,120 +104,15 @@
               "__struct_id": 0,
               "InventoryRes": {
                 "type": "resref",
-                "value": "weapon142"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 0
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 1,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon161"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 2
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 2,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon163"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 3
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 3,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon147"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 4
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 4,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon182"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 5
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 5,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon180"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 6
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 6,
-              "InventoryRes": {
-                "type": "resref",
                 "value": "weapon189"
               },
               "Repos_PosX": {
                 "type": "word",
-                "value": 8
+                "value": 0
               },
               "Repos_Posy": {
                 "type": "word",
                 "value": 0
-              }
-            },
-            {
-              "__struct_id": 7,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon257"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 4
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 2
               }
             }
           ]

--- a/src/utm/merchant12.utm.json
+++ b/src/utm/merchant12.utm.json
@@ -268,7 +268,7 @@
               },
               "InventoryRes": {
                 "type": "resref",
-                "value": "weapon155"
+                "value": "weapon170"
               },
               "Repos_PosX": {
                 "type": "word",
@@ -287,7 +287,7 @@
               },
               "InventoryRes": {
                 "type": "resref",
-                "value": "weapon170"
+                "value": "arrow0"
               },
               "Repos_PosX": {
                 "type": "word",
@@ -306,7 +306,7 @@
               },
               "InventoryRes": {
                 "type": "resref",
-                "value": "arrow0"
+                "value": "bolt0"
               },
               "Repos_PosX": {
                 "type": "word",
@@ -325,30 +325,11 @@
               },
               "InventoryRes": {
                 "type": "resref",
-                "value": "bolt0"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 4
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 5,
-              "Infinite": {
-                "type": "byte",
-                "value": 1
-              },
-              "InventoryRes": {
-                "type": "resref",
                 "value": "bullet0"
               },
               "Repos_PosX": {
                 "type": "word",
-                "value": 5
+                "value": 4
               },
               "Repos_Posy": {
                 "type": "word",

--- a/src/utm/merchant19.utm.json
+++ b/src/utm/merchant19.utm.json
@@ -66,7 +66,7 @@
               "__struct_id": 0,
               "InventoryRes": {
                 "type": "resref",
-                "value": "armor4"
+                "value": "x2_mdrowar036"
               },
               "Repos_PosX": {
                 "type": "word",
@@ -81,7 +81,7 @@
               "__struct_id": 1,
               "InventoryRes": {
                 "type": "resref",
-                "value": "x2_mdrowar036"
+                "value": "x2_mdrowar022"
               },
               "Repos_PosX": {
                 "type": "word",
@@ -96,7 +96,7 @@
               "__struct_id": 2,
               "InventoryRes": {
                 "type": "resref",
-                "value": "x2_mdrowar022"
+                "value": "x2_mdrowar016"
               },
               "Repos_PosX": {
                 "type": "word",
@@ -111,7 +111,7 @@
               "__struct_id": 3,
               "InventoryRes": {
                 "type": "resref",
-                "value": "x2_mdrowar016"
+                "value": "x2_mdrowar001"
               },
               "Repos_PosX": {
                 "type": "word",
@@ -126,7 +126,7 @@
               "__struct_id": 4,
               "InventoryRes": {
                 "type": "resref",
-                "value": "x2_mdrowar001"
+                "value": "x2_mdrowar009"
               },
               "Repos_PosX": {
                 "type": "word",
@@ -141,7 +141,7 @@
               "__struct_id": 5,
               "InventoryRes": {
                 "type": "resref",
-                "value": "x2_mdrowar009"
+                "value": "x2_adrowshl001"
               },
               "Repos_PosX": {
                 "type": "word",
@@ -156,7 +156,7 @@
               "__struct_id": 6,
               "InventoryRes": {
                 "type": "resref",
-                "value": "x2_adrowshl001"
+                "value": "nw_ashmto002"
               },
               "Repos_PosX": {
                 "type": "word",
@@ -171,26 +171,11 @@
               "__struct_id": 7,
               "InventoryRes": {
                 "type": "resref",
-                "value": "nw_ashmto002"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 4
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 3
-              }
-            },
-            {
-              "__struct_id": 8,
-              "InventoryRes": {
-                "type": "resref",
                 "value": "x2_mdrowar029"
               },
               "Repos_PosX": {
                 "type": "word",
-                "value": 6
+                "value": 4
               },
               "Repos_Posy": {
                 "type": "word",
@@ -201,162 +186,7 @@
         }
       },
       {
-        "__struct_id": 4,
-        "ItemList": {
-          "type": "list",
-          "value": [
-            {
-              "__struct_id": 0,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon10"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 0
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 1,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon251"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 1
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 2,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon254"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 3
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 3,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon259"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 5
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 4,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon188"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 6
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 5,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon198"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 7
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 6,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon206"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 8
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 7,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon214"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 6
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 3
-              }
-            },
-            {
-              "__struct_id": 8,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon140"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 7
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 3
-              }
-            },
-            {
-              "__struct_id": 9,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon160"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 3
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 4
-              }
-            }
-          ]
-        }
+        "__struct_id": 4
       },
       {
         "__struct_id": 2

--- a/src/utm/merchant3.utm.json
+++ b/src/utm/merchant3.utm.json
@@ -209,56 +209,11 @@
               "__struct_id": 1,
               "InventoryRes": {
                 "type": "resref",
-                "value": "weapon190"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 1
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 2,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon246"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 2
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 3,
-              "InventoryRes": {
-                "type": "resref",
-                "value": "weapon242"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 4
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 4,
-              "InventoryRes": {
-                "type": "resref",
                 "value": "weapon238"
               },
               "Repos_PosX": {
                 "type": "word",
-                "value": 6
+                "value": 1
               },
               "Repos_Posy": {
                 "type": "word",

--- a/src/utm/merchant5.utm.json
+++ b/src/utm/merchant5.utm.json
@@ -239,26 +239,11 @@
               "__struct_id": 0,
               "InventoryRes": {
                 "type": "resref",
-                "value": "weapon212"
-              },
-              "Repos_PosX": {
-                "type": "word",
-                "value": 0
-              },
-              "Repos_Posy": {
-                "type": "word",
-                "value": 0
-              }
-            },
-            {
-              "__struct_id": 1,
-              "InventoryRes": {
-                "type": "resref",
                 "value": "weapon13"
               },
               "Repos_PosX": {
                 "type": "word",
-                "value": 1
+                "value": 0
               },
               "Repos_Posy": {
                 "type": "word",


### PR DESCRIPTION
Webhook now only displays the number of NPCs (followers/henchmen) that are alive in a PC's party and doesn't count other PCs
Somewhat reduced the number of bugbears in the bandit cave
Slightly reduced the difficulty of the bugbear boss encounters
Venkt is now classified as a semiboss and triggers the defeated webhook
Key bags no longer have the additional property (cursed)
Changed "Neverwinter Rural" mapnotes to "Neverwinter North Gate"
Fixed random spellbooks not loading on the live server
Shop changes:
	Olgerd's (Neverwinter Docks) stock is now mostly considerably lower quality (accidentally increased in loot weight changes)
	Elaith now stocks many fewer t5 items
	Many merchants that stocked fixed unique items no longer do so. A list of items removed:
		Edario: Ankheg Plate Mail, Kondar, Astral Blade, Blessing of the Daystar, Pixie Prick, Ice Reaver, Stonefire Axe, Ravager
		Fenthick: Fist of the Legion
		Nyatar: Teneraard's Sickle, Renewal, Tethir-Wood Cudgel
		Rizolvir: Enkidu's Armor, Angurvadal, Dragon's Breath, King's Scythe, Spear of Withering, Gladiator's Club, Heirs of Osiris, Hammer of the Wisp, Petty's Tempest, Jhor the Bleeder, Vermin's Bane
		Uncus: The Nightthief's Claw
	To make up for this, Pawnshops have a now have a significantly increased chance to stock random unique items
	