### PR TITLE
Missing map pins and henchman fixes

### DIFF
--- a/src/gic/hr_south2.gic.json
+++ b/src/gic/hr_south2.gic.json
@@ -786,6 +786,13 @@
           "type": "cexostring",
           "value": "This is the default waypoint you may place to set a patrol path for a creature or NPC.\r\n1. Create the creature and either use its current Tag or fill in a new one.\r\n2. Place or make sure the WalkWayPoints() is within the body of the On Spawn script for the creature.\r\n3. Place a series of waypoints along the route you wish the creature to walk.\r\n4. Select all of the newly created waypoints and right click. Choose the Create Set option.\r\n5. The waypoint set will have a set name of \"WP_\" + NPC Tag. Thus if an NPC with the Tag \"Guard\" will have a waypoint set called \"WP_Guard\". Note that Tags are case sensitive."
         }
+      },
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": "On the Advanced tab, replace <Place text here> with whatever information you wish to appear on the Map of an area."
+        }
       }
     ]
   }

--- a/src/gic/nw_sgate.gic.json
+++ b/src/gic/nw_sgate.gic.json
@@ -422,6 +422,20 @@
           "type": "cexostring",
           "value": "This is the default waypoint you may place to set a patrol path for a creature or NPC.\r\n1. Create the creature and either use its current Tag or fill in a new one.\r\n2. Place or make sure the WalkWayPoints() is within the body of the On Spawn script for the creature.\r\n3. Place a series of waypoints along the route you wish the creature to walk.\r\n4. Select all of the newly created waypoints and right click. Choose the Create Set option.\r\n5. The waypoint set will have a set name of \"WP_\" + NPC Tag. Thus if an NPC with the Tag \"Guard\" will have a waypoint set called \"WP_Guard\". Note that Tags are case sensitive."
         }
+      },
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": "On the Advanced tab, replace <Place text here> with whatever information you wish to appear on the Map of an area."
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": "On the Advanced tab, replace <Place text here> with whatever information you wish to appear on the Map of an area."
+        }
       }
     ]
   }

--- a/src/gic/nw_southroad.gic.json
+++ b/src/gic/nw_southroad.gic.json
@@ -1031,6 +1031,13 @@
           "type": "cexostring",
           "value": "On the Advanced tab, replace <Place text here> with whatever information you wish to appear on the Map of an area."
         }
+      },
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": "On the Advanced tab, replace <Place text here> with whatever information you wish to appear on the Map of an area."
+        }
       }
     ]
   }

--- a/src/git/hr_south2.git.json
+++ b/src/git/hr_south2.git.json
@@ -46879,6 +46879,69 @@
           "type": "float",
           "value": 5.01
         }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 1
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 1
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "id": 14814,
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNote": {
+          "id": 14815,
+          "type": "cexolocstring",
+          "value": {
+            "0": "Waterfall Beach"
+          }
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "NW_MAPNOTE001"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "nw_mapnote001"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": 0.0
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 4.7585
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": 1.0
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 205.419
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 5.02
+        }
       }
     ]
   }

--- a/src/git/nw_sgate.git.json
+++ b/src/git/nw_sgate.git.json
@@ -20563,6 +20563,132 @@
           "type": "float",
           "value": 10.0
         }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 1
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 1
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "id": 14814,
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNote": {
+          "id": 14815,
+          "type": "cexolocstring",
+          "value": {
+            "0": "Neverwinter"
+          }
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "NW_MAPNOTE001"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "nw_mapnote001"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": 0.0
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 72.2834
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": 1.0
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 144.7814
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 10.0
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 1
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 1
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "id": 14814,
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNote": {
+          "id": 14815,
+          "type": "cexolocstring",
+          "value": {
+            "0": "South Road"
+          }
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "NW_MAPNOTE001"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "nw_mapnote001"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": 0.0
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 74.8383
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": 1.0
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 5.0435
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 10.02
+        }
       }
     ]
   }

--- a/src/git/nw_southroad.git.json
+++ b/src/git/nw_southroad.git.json
@@ -62526,6 +62526,69 @@
           "type": "float",
           "value": 5.02
         }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 1
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 1
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "id": 14814,
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNote": {
+          "id": 14815,
+          "type": "cexolocstring",
+          "value": {
+            "0": "Neverwinter South Gate"
+          }
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "NW_MAPNOTE001"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "nw_mapnote001"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": 0.0
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 75.0568
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": 1.0
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 234.7746
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 5.02
+        }
       }
     ]
   }

--- a/src/nss/ai_onheartb.nss
+++ b/src/nss/ai_onheartb.nss
@@ -49,7 +49,7 @@ void main()
 // only attack or move to the ambush location when not in combat, otherwise combat can be interrupted
         if (!GetIsInCombat(OBJECT_SELF))
         {
-            object oTarget = GetLocalObject(oTarget, "ambush_target");
+            object oTarget = GetLocalObject(OBJECT_SELF, "ambush_target");
 
 // attack ambush target if seen or target is alive
             if (!GetIsDead(oTarget) && (GetObjectSeen(oTarget) || GetObjectHeard(oTarget)))

--- a/src/nss/hen_banter.nss
+++ b/src/nss/hen_banter.nss
@@ -660,8 +660,10 @@ void main()
    }
 
     int nRandom = Random(nCount)+1;
-
-    SpeakString(GetLocalString(OBJECT_SELF, "banter"+IntToString(nRandom)));
-    ClearAllActions();
-    PlaySound(GetLocalString(OBJECT_SELF, "banter_sound"+IntToString(nRandom)));
+    if (nCount > 0)
+    {
+        SpeakString(GetLocalString(OBJECT_SELF, "banter"+IntToString(nRandom)));
+        ClearAllActions();
+        PlaySound(GetLocalString(OBJECT_SELF, "banter_sound"+IntToString(nRandom)));
+    }
 }

--- a/src/nss/hen_chk_master.nss
+++ b/src/nss/hen_chk_master.nss
@@ -1,14 +1,23 @@
+#include "inc_henchman"
+
 int StartingConditional()
 {
 // Check if speaker is the master of the henchman
 
     string sMaster = GetLocalString(GetModule(), GetResRef(OBJECT_SELF)+"_master");
+    object oPC = GetPCSpeaker();
 
 // no master
     if (sMaster == "") return FALSE;
 
 // incorrect master
-    if (sMaster != GetObjectUUID(GetPCSpeaker())) return FALSE;
+    if (sMaster != GetObjectUUID(oPC)) return FALSE;
+    
+    // After curing petrification, this will add them back to the party
+    if (!GetIsObjectValid(GetMaster(OBJECT_SELF)))
+    {
+        SetMaster(OBJECT_SELF, oPC);
+    }
 
     return TRUE;
 

--- a/src/nss/hen_respawn.nss
+++ b/src/nss/hen_respawn.nss
@@ -1,21 +1,14 @@
+#include "inc_henchman"
+
 void main()
 {
-    if (!GetIsObjectValid(GetObjectByTag("hen_daelan")))
-        CreateObject(OBJECT_TYPE_CREATURE, "hen_daelan", GetLocation(GetObjectByTag("hen_daelan_spawn_point")));
-    if (!GetIsObjectValid(GetObjectByTag("hen_linu")))
-        CreateObject(OBJECT_TYPE_CREATURE, "hen_linu", GetLocation(GetObjectByTag("hen_linu_spawn_point")));
-    if (!GetIsObjectValid(GetObjectByTag("hen_sharwyn")))
-        CreateObject(OBJECT_TYPE_CREATURE, "hen_sharwyn", GetLocation(GetObjectByTag("hen_sharwyn_spawn_point")));
-    if (!GetIsObjectValid(GetObjectByTag("hen_tomi")))
-        CreateObject(OBJECT_TYPE_CREATURE, "hen_tomi", GetLocation(GetObjectByTag("hen_tomi_spawn_point")));
-    if (!GetIsObjectValid(GetObjectByTag("hen_grimgnaw")))
-        CreateObject(OBJECT_TYPE_CREATURE, "hen_grimgnaw", GetLocation(GetObjectByTag("hen_grimgnaw_spawn_point")));
-    if (!GetIsObjectValid(GetObjectByTag("hen_boddyknock")))
-        CreateObject(OBJECT_TYPE_CREATURE, "hen_boddyknock", GetLocation(GetObjectByTag("hen_boddyknock_spawn_point")));
-    if (!GetIsObjectValid(GetObjectByTag("hen_valen")))
-        CreateObject(OBJECT_TYPE_CREATURE, "hen_valen", GetLocation(GetObjectByTag("hen_valen_spawn_point")));
-    if (!GetIsObjectValid(GetObjectByTag("hen_nathyrra")))
-        CreateObject(OBJECT_TYPE_CREATURE, "hen_nathyrra", GetLocation(GetObjectByTag("hen_nathyrra_spawn_point")));
-    if (!GetIsObjectValid(GetObjectByTag("hen_bim")))
-        CreateObject(OBJECT_TYPE_CREATURE, "hen_bim", GetLocation(GetObjectByTag("hen_bim_spawn_point")));
+    TFNRespawnHenchman("hen_daelan");
+    TFNRespawnHenchman("hen_linu");
+    TFNRespawnHenchman("hen_sharwyn");
+    TFNRespawnHenchman("hen_tomi");
+    TFNRespawnHenchman("hen_grimgnaw");
+    TFNRespawnHenchman("hen_boddyknock");
+    TFNRespawnHenchman("hen_valen");
+    TFNRespawnHenchman("hen_nathyrra");
+    TFNRespawnHenchman("hen_bim");
 }

--- a/src/utc/hen_bim.utc.json
+++ b/src/utc/hen_bim.utc.json
@@ -146,7 +146,7 @@
   },
   "DecayTime": {
     "type": "dword",
-    "value": 5000
+    "value": 32767000
   },
   "Deity": {
     "type": "cexostring",

--- a/src/utc/hen_boddyknock.utc.json
+++ b/src/utc/hen_boddyknock.utc.json
@@ -246,7 +246,7 @@
   },
   "DecayTime": {
     "type": "dword",
-    "value": 5000
+    "value": 32767000
   },
   "Deity": {
     "type": "cexostring",

--- a/src/utc/hen_nathyrra.utc.json
+++ b/src/utc/hen_nathyrra.utc.json
@@ -146,7 +146,7 @@
   },
   "DecayTime": {
     "type": "dword",
-    "value": 5000
+    "value": 32767000
   },
   "Deity": {
     "type": "cexostring",

--- a/src/utc/hen_valen.utc.json
+++ b/src/utc/hen_valen.utc.json
@@ -146,7 +146,7 @@
   },
   "DecayTime": {
     "type": "dword",
-    "value": 5000
+    "value": 32767000
   },
   "Deity": {
     "type": "cexostring",


### PR DESCRIPTION
Added missing map pins to Neverwinter South Gate, South Road and High Road South - Lower
Henchmen without banter lines defined should no longer send "empty" chat lines
Fixes towards henchmen prematurely disappearing on death and not being revivable
Henchmen should no longer think they are "attached" to their previous master after respawning back at their hiring spots
Talking to henchmen that were cured from petrification should now add them back to the party
Henchmen now belong to the merchant faction, which may or may not help with unbound hostility issues