### PR TITLE
Fix forced respawn after salve cures petrification, fix divide by zero refresh script

### DIFF
--- a/src/nss/area_refresh_pet.nss
+++ b/src/nss/area_refresh_pet.nss
@@ -25,20 +25,23 @@ void CleanAndSpawnPetrified(string sCreature)
     DeleteLocalInt(OBJECT_SELF, sVar + "_count");
     
     int nNumSpawnPoints = GetLocalInt(OBJECT_SELF, "petrified_Petrified" + sCreature);
-    int nChance = (1000*nNumSpawns)/nNumSpawnPoints;
-    int nNumberSpawned = 0;
-    for (i=0; i<nNumSpawnPoints; i++)
+    if (nNumSpawnPoints > 0)
     {
-        if (Random(1000) < nChance)
+        int nChance = (1000*nNumSpawns)/nNumSpawnPoints;
+        int nNumberSpawned = 0;
+        for (i=0; i<nNumSpawnPoints; i++)
         {
-            SetLocalInt(OBJECT_SELF, sVar + "_count", GetLocalInt(OBJECT_SELF, sVar + "_count") + 1);
-            location lLoc = GetLocalLocation(OBJECT_SELF, "petrified_Petrified" + sCreature + IntToString(i));
-            object oNew = CreateObject(OBJECT_TYPE_CREATURE, sResRef, lLoc);
-            SetLocalObject(OBJECT_SELF, "PetrifiedCreature_" + sCreature + IntToString(nNumberSpawned), oNew);
-            nNumberSpawned++;
-            AssignCommand(oNew, SetFacing(IntToFloat(Random(360))));
-            DelayCommand(3.0, ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectPetrify(), oNew));
-            SetLocalInt(oNew, "no_credit", 1);
+            if (Random(1000) < nChance)
+            {
+                SetLocalInt(OBJECT_SELF, sVar + "_count", GetLocalInt(OBJECT_SELF, sVar + "_count") + 1);
+                location lLoc = GetLocalLocation(OBJECT_SELF, "petrified_Petrified" + sCreature + IntToString(i));
+                object oNew = CreateObject(OBJECT_TYPE_CREATURE, sResRef, lLoc);
+                SetLocalObject(OBJECT_SELF, "PetrifiedCreature_" + sCreature + IntToString(nNumberSpawned), oNew);
+                nNumberSpawned++;
+                AssignCommand(oNew, SetFacing(IntToFloat(Random(360))));
+                DelayCommand(3.0, ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectPetrify(), oNew));
+                SetLocalInt(oNew, "no_credit", 1);
+            }
         }
     }
 }

--- a/src/nss/on_mod_heartb.nss
+++ b/src/nss/on_mod_heartb.nss
@@ -135,6 +135,11 @@ void DoRevive(object oDead)
                             }
                             eEffect = GetNextEffect(oDead);
                         }
+                        if (GetIsPC(oDead))
+                        {
+                            SQLocalsPlayer_DeleteInt(oDead, "PETRIFIED");
+                        }
+                        DeleteLocalInt(oDead, "PETRIFIED");
                         object oFactionPC = GetFirstFactionMember(oDead);
                         while (GetIsObjectValid(oFactionPC))
                         {

--- a/src/nss/party_credit.nss
+++ b/src/nss/party_credit.nss
@@ -272,7 +272,7 @@ void SetPartyData()
    }
 
 
-   if (nPlayerSize > 0) fAverageLevel = IntToFloat(nTotalLevels) / IntToFloat(nTotalSize);
+   if (nPlayerSize > 0) fAverageLevel = IntToFloat(nTotalLevels) / IntToFloat(max(1, nTotalSize));
 
    float fHighestLevel = IntToFloat(nHighestLevel);
    if (fHighestLevel > fAverageLevel) fAverageLevel = fHighestLevel;


### PR DESCRIPTION
Self-curing petrification with your salve would not clear the petrification flag, meaning that the next time you die you get warped to respawn immediately.