### PR TITLE
Revert "Loot assignment evenness"

### DIFF
--- a/src/nss/inc_adventurer.nss
+++ b/src/nss/inc_adventurer.nss
@@ -205,7 +205,7 @@ int SelectAdventurerPath()
     }
     int nRandom = Random(nTotalWeight+1);
     i = 1;
-    while (nRandom > 0 && i < ADVENTURER_PATH_HIGHEST)
+    while (nRandom > 0 && i <= ADVENTURER_PATH_HIGHEST)
     {
         nRandom -= GetAdventurerPathWeight(i);
         i++;

--- a/src/nss/inc_loot.nss
+++ b/src/nss/inc_loot.nss
@@ -104,22 +104,9 @@ const int STORE_RANDOM_T5_CHANCE = 9;
 // START PROTOTYPES
 // ===========================================================
 
-// Select a tier Item. Specific Tier granted if nTier is 1-5.
-// Valid types: "Armor", "Melee", "Range", "Misc, "Apparel"
-// "Potion", "ScrollsDivine", "ScrollsArcane"
-// The item returned by this function WILL BE IN A CONTAINER IN THE LOOT AREA.
-// This does NOT MOVE OR MAKE A COPY OF THE ITEM in oContainer. oContainer is used to make sure the item in question
-// is appropriate to generate in some situations (eg gems in stores are pointless)
-// Use CopyTierItemToContainer to copy the return from this function to its final destination.
-object SelectTierItem(int iCR, int iAreaCR, string sType = "", int nTier = 0, object oContainer=OBJECT_INVALID, int bNonUnique = FALSE);
-
-// Copy oItem (which should be from SelectTierItem) to oContainer and correctly initialise it
-object CopyTierItemToContainer(object oItem, object oContainer);
-
 // Generate a tier Item. Specific Tier granted if nTier is 1-5.
 // Valid types: "Armor", "Melee", "Range", "Misc, "Apparel"
 // "Potion", "ScrollsDivine", "ScrollsArcane"
-// An amalgamation of SelectTierItem and CopyTierItemToContainer for convenience.
 object GenerateTierItem(int iCR, int iAreaCR, object oContainer, string sType = "", int nTier = 0, int bNonUnique = FALSE);
 
 // Open a personal loot. Called from a containing object.
@@ -163,185 +150,11 @@ void LootDebugOutput();
 // Reset the loot tracker.
 void ResetLootDebug();
 
-// ====================
-// OWINGS
-// ====================
-
-// "Owings" and "tracked debt" (because it feels bad when someone gets all the bad loot)
-// A PC tracks how much each henchman and other player "owes" them (based on gold value disparity)
-// -> Use this to weight the probability of who gets what items
-// The PC-henchman owings are tracked in the PC BIC DB
-// PC-PC owings are, at least for now, tracked in a serverside Cdkey-Cdkey db
-// This might be a bit weird but permanently tracking characters seems like a significantly more difficult problem
-
-// For the sake of implementation, each henchman/PC in the party starts has 1000 "points"
-// If they "owe" some other party member(s) loot, they give some of their points to the people they owe to
-// Then roll a d(total number of points) and see whose band the roll lands in, and they get the item
-
-// This falls down when one party member tries to give out more than their 1000 "points"
-// ... in which case their points need to instead be distributed relative to the people demanding them
-// eg if three people demand 100/400/800 points from me (total 1300), first person gets 100/1.3, second gets 400/1.3, third gets 800/1.3
-
-// Return the amount of gold value oDebtor owes oReceiver.
-// If oReceiver instead owes oDebtor, the value returned is negative.
-int GetOwedGoldValue(object oReceiver, object oDebtor);
-
-// Return how many "owing points" to transfer from oDebtor to oReceiver for getting an item of nItemGoldValue
-// If oReceiver owes oDebtor value, this will be negative.
-int GetLootWeightingTransferBasedOnOwings(object oReceiver, object oDebtor, int nItemGoldValue);
-
-// Increase the debt of oDebtor to oReceiver by nAmount.
-void AdjustOwedGoldValue(object oReceiver, object oDebtor, int nAmount);
-
-// Whether or not to write debug messages about loot owing to the log
-const int LOOT_OWING_DEBUG = 1;
-
 // ===========================================================
 // START FUNCTIONS
 // ===========================================================
 
 const string PERSONAL_LOOT_GOLD_AMOUNT = "personal_loot_gold";
-
-// Return the amount of gold value oDebtor owes oReceiver.
-// If oReceiver instead owes oDebtor, the value returned is negative.
-int GetOwedGoldValue(object oReceiver, object oDebtor)
-{
-    if (!GetIsPC(oReceiver) && !GetIsPC(oDebtor))
-    {
-        int nSaved = GetCampaignInt("lootowings", "hench_" + GetTag(oReceiver) + "-" + GetTag(oDebtor));
-        if (nSaved == 0)
-        {
-            nSaved = GetCampaignInt("lootowings", "hench_" + GetTag(oDebtor) + "-" + GetTag(oReceiver)) * -1;
-        }
-        return nSaved;
-    }
-    if (GetIsPC(oReceiver) && GetIsPC(oDebtor))
-    {
-        int nSaved = GetCampaignInt("lootowings", GetPCPublicCDKey(oReceiver) + "-" + GetPCPublicCDKey(oDebtor));
-        if (nSaved == 0)
-        {
-            nSaved = GetCampaignInt("lootowings", GetPCPublicCDKey(oDebtor) + "-" + GetPCPublicCDKey(oReceiver)) * -1;
-        }
-        return nSaved;
-    }
-    // If we get here, exactly one of oDebtor and oReceiver is a PC and the other is a henchman
-    object oPC;
-    object oHen;
-    if (GetIsPC(oReceiver))
-    {
-        oPC = oReceiver;
-        oHen = oDebtor;
-    }
-    else
-    {
-        oPC = oDebtor;
-        oHen = oReceiver;
-    }
-    // Check the PC's BIC db for the amount
-    int nAmt = SQLocalsPlayer_GetInt(oPC, "lootowing_" + GetTag(oHen));
-    // This is how much the hench owes the player, make it negative if the function was called the other way round
-    if (oDebtor == oPC)
-    {
-        nAmt *= -1;
-    }
-    return nAmt;    
-}
-
-// Return how many "owing points" to transfer from oDebtor to oReceiver for getting an item of nItemGoldValue
-// If oReceiver owes oDebtor value, this will be negative.
-int GetLootWeightingTransferBasedOnOwings(object oReceiver, object oDebtor, int nItemGoldValue)
-{
-    int nDebt = GetOwedGoldValue(oReceiver, oDebtor);
-    // This is the fastest outcome, and will cause dividing by zero later if not dealt with now
-    if (nDebt == 0)
-    {
-        return 0;
-    }
-    if (nDebt < 0)
-    {
-        return -1*GetLootWeightingTransferBasedOnOwings(oDebtor, oReceiver, nItemGoldValue);
-    }
-    // Base premise:
-    // points to transfer when owing = 10 + (itemvalue/min(debt, 22000))^1.5 * 55
-    // min(debt, 22000) is because 22000 is the highest possible in one item (upper value bracket of t5)
-    // adding 10 means the split is 60/40 for all items
-    // the exponential expression means that items are much more skewed the closer they are to the debt size
-    // In TFN item gold value does not scale linearly with "desirableness" and this is an attempt to capture that
-    
-    // If the item value > debt size, calc how much it exceeds by and subtract that from the item value
-    // this will mean that the curve mirrors as value passes debt size and rapidly drops down to more even values
-    // as the debt is exceeded
-    if (nDebt < nItemGoldValue)
-    {
-        // (but don't make the item value go negative)
-        nItemGoldValue = max(0, nDebt - (nItemGoldValue - nDebt));
-    }
-    float fItemGoldValue = IntToFloat(nItemGoldValue);
-    float fDebt = IntToFloat(min(nDebt, 22000));
-    float fTransfer = 100 + (pow(fItemGoldValue/fDebt, 1.5) * 850);
-    return FloatToInt(fTransfer);
-}
-
-// Increase the debt of oDebtor to oReceiver by nAmount.
-void AdjustOwedGoldValue(object oReceiver, object oDebtor, int nAmount)
-{
-    if (!GetIsPC(oReceiver) && !GetIsPC(oDebtor))
-    {      
-        string sVar = "hench_" + GetTag(oReceiver) + "-" + GetTag(oDebtor);
-        int nSaved = GetCampaignInt("lootowings", sVar);
-        if (nSaved == 0)
-        {
-            sVar = "hench_" + GetTag(oDebtor) + "-" + GetTag(oReceiver);
-            nSaved = GetCampaignInt("lootowings", sVar);
-            nAmount *= -1;
-        }
-        if (LOOT_OWING_DEBUG)
-        {
-            WriteTimestampedLogEntry("Added " + IntToString(nAmount) + " to the amount " + GetName(oDebtor) + " owes " + GetName(oReceiver) + ": now " + IntToString(nSaved + nAmount));
-        }
-        SetCampaignInt("lootowings", sVar, nSaved + nAmount);
-        return;
-    }
-    if (GetIsPC(oReceiver) && GetIsPC(oDebtor))
-    {
-        // Figure out which one is being used
-        string sVar = GetPCPublicCDKey(oReceiver) + "-" + GetPCPublicCDKey(oDebtor);
-        int nSaved = GetCampaignInt("lootowings", sVar);
-        if (nSaved == 0)
-        {
-            sVar = GetPCPublicCDKey(oDebtor) + "-" + GetPCPublicCDKey(oReceiver);
-            nSaved = GetCampaignInt("lootowings", sVar);
-            nAmount *= -1;
-        }
-        if (LOOT_OWING_DEBUG)
-        {
-            WriteTimestampedLogEntry("Added " + IntToString(nAmount) + " to the amount " + GetName(oDebtor) + " owes " + GetName(oReceiver) + ": now " + IntToString(nSaved + nAmount));
-        }
-        SetCampaignInt("lootowings", sVar, nSaved + nAmount);
-        return;
-    }
-    // If we get here, exactly one of oDebtor and oReceiver is a PC and the other is a henchman
-    object oPC;
-    object oHen;
-    if (GetIsPC(oReceiver))
-    {
-        oPC = oReceiver;
-        oHen = oDebtor;
-    }
-    else
-    {
-        oPC = oDebtor;
-        oHen = oReceiver;
-        nAmount *= -1;
-    }
-    // Check the PC's BIC db for the amount
-    int nSaved = SQLocalsPlayer_GetInt(oPC, "lootowing_" + GetTag(oHen));
-    if (LOOT_OWING_DEBUG)
-    {
-        WriteTimestampedLogEntry("Added " + IntToString(nAmount) + " to the amount " + GetName(oHen) + " owes " + GetName(oPC) + ": now " + IntToString(nSaved + nAmount));
-    }
-    SQLocalsPlayer_SetInt(oPC, "lootowing_" + GetTag(oHen), nSaved + nAmount);
-}
 
 // ---------------------------------------------------------
 // This function is used to determine the tier of the drop.
@@ -435,7 +248,10 @@ string DetermineTier(int iCR, int iAreaCR, string sType = "")
     return sTier;
 }
 
-object SelectTierItem(int iCR, int iAreaCR, string sType = "", int nTier = 0, object oContainer=OBJECT_INVALID, int bNonUnique = FALSE)
+// ---------------------------------------------------------
+// This function is used to generate a tier item.
+// ---------------------------------------------------------
+object GenerateTierItem(int iCR, int iAreaCR, object oContainer, string sType = "", int nTier = 0, int bNonUnique = FALSE)
 {
     string sTier = DetermineTier(iCR, iAreaCR, sType);
     string sRarity = "";
@@ -571,36 +387,11 @@ object SelectTierItem(int iCR, int iAreaCR, string sType = "", int nTier = 0, ob
     {
         return OBJECT_INVALID; // do not allow plot items to be created on stores
     }
-    
-    int nCount = GetLocalInt(GetModule(), sType);
-    SetLocalInt(GetModule(), sType, nCount+1);
-    
-    return oItem;
-}
 
-
-// ---------------------------------------------------------
-// This function is used to generate a tier item.
-// ---------------------------------------------------------
-object GenerateTierItem(int iCR, int iAreaCR, object oContainer, string sType = "", int nTier = 0, int bNonUnique = FALSE)
-{
-    object oItem = SelectTierItem(iCR, iAreaCR, sType, nTier, oContainer, bNonUnique);
-    object oNewItem = CopyTierItemToContainer(oItem, oContainer);
-    return oNewItem;
-}
-
-object CopyTierItemToContainer(object oItem, object oContainer)
-{
-    if (!GetIsObjectValid(oItem))
-    {
-        return OBJECT_INVALID;
-    }
-    if (!GetIsObjectValid(oContainer))
-    {
-        return OBJECT_INVALID;
-    }
     object oNewItem = CopyItem(oItem, oContainer, TRUE);
 
+    int nCount = GetLocalInt(GetModule(), sType);
+    SetLocalInt(GetModule(), sType, nCount+1);
 
     //int nRarityCount = GetLocalInt(GetModule(), sRarity);
     //SetLocalInt(GetModule(), sRarity, nRarityCount+1);
@@ -624,10 +415,9 @@ object CopyTierItemToContainer(object oItem, object oContainer)
 // ---------------------------------------------------------
 // Generates loot. Typically used for creatures or containers.
 // ---------------------------------------------------------
-
-object SelectLoot(object oLootSource, object oDestinationContainer=OBJECT_INVALID)
+object GenerateLoot(object oLootSource, object oDestinationContainer=OBJECT_INVALID)
 {
-     
+    
    if (GetLocalInt(GetModule(), "treasure_ready") != 1)
    {
        SendMessageToAllPCs("Treasure isn't ready. No treasure will be generated.");
@@ -645,6 +435,8 @@ object SelectLoot(object oLootSource, object oDestinationContainer=OBJECT_INVALI
        oDestinationContainer = oLootSource;
    }
    
+   if (!GetHasInventory(oDestinationContainer)) return OBJECT_INVALID; // stop if the container has no inventory
+
    int iCR = GetLocalInt(oLootSource, "cr");
    int iAreaCR = GetLocalInt(oLootSource, "area_cr");
 
@@ -673,22 +465,22 @@ object SelectLoot(object oLootSource, object oDestinationContainer=OBJECT_INVALI
    while (TRUE)
    {
        nItemRoll = nItemRoll - nMiscWeight;
-       if (nItemRoll <= 0) {oItem = SelectTierItem(iCR, iAreaCR, "Misc", 0, oDestinationContainer);break;}
+       if (nItemRoll <= 0) {oItem = GenerateTierItem(iCR, iAreaCR, oDestinationContainer, "Misc");break;}
 
        nItemRoll = nItemRoll - nScrollsWeight;
-       if (nItemRoll <= 0) {oItem = SelectTierItem(iCR, iAreaCR, "Scrolls", 0, oDestinationContainer);break;}
+       if (nItemRoll <= 0) {oItem = GenerateTierItem(iCR, iAreaCR, oDestinationContainer, "Scrolls");break;}
 
        nItemRoll = nItemRoll - nPotionsWeight;
-       if (nItemRoll <= 0) {oItem = SelectTierItem(iCR, iAreaCR, "Potions", 0, oDestinationContainer);break;}
+       if (nItemRoll <= 0) {oItem = GenerateTierItem(iCR, iAreaCR, oDestinationContainer, "Potions");break;}
 
        nItemRoll = nItemRoll - nWeaponWeight;
-       if (nItemRoll <= 0) {oItem = SelectTierItem(iCR, iAreaCR, "Weapon", 0, oDestinationContainer);break;}
+       if (nItemRoll <= 0) {oItem = GenerateTierItem(iCR, iAreaCR, oDestinationContainer, "Weapon");break;}
 
        nItemRoll = nItemRoll - nArmorWeight;
-       if (nItemRoll <= 0) {oItem = SelectTierItem(iCR, iAreaCR, "Armor", 0, oDestinationContainer);break;}
+       if (nItemRoll <= 0) {oItem = GenerateTierItem(iCR, iAreaCR, oDestinationContainer, "Armor");break;}
 
        nItemRoll = nItemRoll - nApparelWeight;
-       if (nItemRoll <= 0) {oItem = SelectTierItem(iCR, iAreaCR, "Apparel", 0, oDestinationContainer);break;}
+       if (nItemRoll <= 0) {oItem = GenerateTierItem(iCR, iAreaCR, oDestinationContainer, "Apparel");break;}
    }
 
     if (ShouldDebugLoot())
@@ -767,20 +559,6 @@ object SelectLoot(object oLootSource, object oDestinationContainer=OBJECT_INVALI
     }
 
     return oItem;
-}
-
-object GenerateLoot(object oLootSource, object oDestinationContainer=OBJECT_INVALID)
-{
-    if (!GetIsObjectValid(oDestinationContainer))
-    {
-        oDestinationContainer = OBJECT_SELF;
-    }
-    if (!GetHasInventory(oDestinationContainer))
-    {
-        return OBJECT_INVALID;
-    }
-    object oItem = SelectLoot(oLootSource, oDestinationContainer);
-    return CopyTierItemToContainer(oItem, oDestinationContainer);
 }
 
 void DecrementLootAndDestroyIfEmpty(object oOpener, object oLootParent, object oPersonalLoot)

--- a/src/nss/party_credit.nss
+++ b/src/nss/party_credit.nss
@@ -32,21 +32,11 @@ object GetLocalArrayObject(object oObject, string sArrayName, int nIndex)
    return GetLocalObject(oObject, sVarName);
 }
 
+
 // * Simulates storing a local object in an array on an object.
 void SetLocalArrayObject(object oObject, string sArrayName, int nIndex, object oValue)
 {
    SetLocalObject(oObject, sArrayName + IntToString(nIndex), oValue);
-}
-
-int GetLocalArrayInt(object oObject, string sArrayName, int nIndex)
-{
-   string sVarName = sArrayName + IntToString(nIndex);
-   return GetLocalInt(oObject, sVarName);
-}
-
-void SetLocalArrayInt(object oObject, string sArrayName, int nIndex, int nValue)
-{
-   SetLocalInt(oObject, sArrayName + IntToString(nIndex), nValue);
 }
 
 void SendLootMessage(object oHench, object oItem)
@@ -302,174 +292,6 @@ void SetPartyData()
    Party.LevelGap = nHigh - nLow;
 }
 
-// Take the loot item (in the treasure area chest) and return the party member that should recieve it.
-object DeterminePartyMemberThatGetsItem(object oItem, int nStartWeights=1000)
-{
-    int nWasIdentified = GetIdentified(oItem);
-    SetIdentified(oItem, 1);
-    int nItemValue = GetGoldPieceValue(oItem);
-    if (LOOT_OWING_DEBUG)
-    {
-        WriteTimestampedLogEntry("Try to assign: " + GetName(oItem) + ", value = " +IntToString(nItemValue));
-    }
-    SetIdentified(oItem, nWasIdentified);
-    if (!GetIsObjectValid(oItem))
-    {
-        return OBJECT_INVALID;
-    }
-    // Recommended reading: inc_loot -> "owings" section
-    // First, simply go through everyone and work out weightings
-    // combinations need to be done EXACTLY once, PC1 vs Daelan then Daelan vs PC1 will undo itself
-    int nNumLootRecievers = Party.PlayerSize + Party.HenchmanSize;
-    int i, j;
-    // Everyone starts on 1000
-    for (i=1; i<=nNumLootRecievers; i++)
-    {
-        SetLocalArrayInt(OBJECT_SELF, "LootWeights", i, nStartWeights);
-    }
-    object oRecipient;
-    for (i=1; i<=nNumLootRecievers; i++)
-    {
-        if (i <= Party.PlayerSize)
-        {
-            oRecipient = GetLocalArrayObject(OBJECT_SELF, "Players", i);
-        }
-        else
-        {
-            oRecipient = GetLocalArrayObject(OBJECT_SELF, "Henchmans", i - Party.PlayerSize);
-        }
-        // Check all other party members after this index
-        // this should avoid the above mentioned "reverse" cases
-        int nWeight = GetLocalArrayInt(OBJECT_SELF, "LootWeights", i);
-        for (j=i+1; j<=nNumLootRecievers; j++)
-        {
-            object oDebtor;
-            if (j <= Party.PlayerSize)
-            {
-                oDebtor = GetLocalArrayObject(OBJECT_SELF, "Players", j);
-            }
-            else
-            {
-                oDebtor = GetLocalArrayObject(OBJECT_SELF, "Henchmans", j - Party.PlayerSize);
-            }
-            int nTransfer = GetLootWeightingTransferBasedOnOwings(oRecipient, oDebtor, nItemValue);
-            int nDebtorWeight = GetLocalArrayInt(OBJECT_SELF, "LootWeights", j);
-            nDebtorWeight -= nTransfer;
-            nWeight += nTransfer;
-            if (LOOT_OWING_DEBUG)
-            {
-                WriteTimestampedLogEntry(GetName(oDebtor) + " owes " + IntToString(GetOwedGoldValue(oRecipient, oDebtor)) + " to " + GetName(oRecipient) + ": transfer " + IntToString(nTransfer) + " weighting -> " + GetName(oRecipient) + "=" + IntToString(nWeight) + ", " + GetName(oDebtor) + "=" + IntToString(nDebtorWeight));
-            }
-            SetLocalArrayInt(OBJECT_SELF, "LootWeights", j, nDebtorWeight);
-        }
-        SetLocalArrayInt(OBJECT_SELF, "LootWeights", i, nWeight);
-    }
-    // Make sure no weight ended up negative, if it did, repeat with a higher nStartWeights
-    int nLowestWeight = 999999;
-    int nTotalWeight = nStartWeights * nNumLootRecievers;
-    for (i=1; i<=nNumLootRecievers; i++)
-    {
-        int nWeight = GetLocalArrayInt(OBJECT_SELF, "LootWeights", i);
-        if (LOOT_OWING_DEBUG)
-        {
-            object oPerson;
-            if (i <= Party.PlayerSize)
-            {
-                oPerson = GetLocalArrayObject(OBJECT_SELF, "Players", i);
-            }
-            else
-            {
-                oPerson = GetLocalArrayObject(OBJECT_SELF, "Henchmans", i - Party.PlayerSize);
-            }
-            WriteTimestampedLogEntry(GetName(oPerson) + " = " + IntToString(nWeight) + " or " + IntToString(100*nWeight/nTotalWeight) + " percent");
-        }
-        if (nWeight < nLowestWeight)
-        {
-            nLowestWeight = nWeight;
-        }
-    }
-    if (LOOT_OWING_DEBUG)
-    {
-        WriteTimestampedLogEntry("Lowest weight = " + IntToString(nLowestWeight));
-    }
-    if (nLowestWeight < 0)
-    {
-        // I don't think this is perfect, but it is by far the easiest way to get out of this particular hole
-        // and solve the negative weight problem
-        if (LOOT_OWING_DEBUG)
-        {
-            WriteTimestampedLogEntry("Lowest weight is negative, try again with start points +" + IntToString(nLowestWeight*-1));
-        }
-        return DeterminePartyMemberThatGetsItem(oItem, nStartWeights + (nLowestWeight*-1));
-    }
-    
-    int nRolledWeight = Random(nTotalWeight)+1;
-    if (LOOT_OWING_DEBUG)
-    {
-        WriteTimestampedLogEntry("Total weight = " + IntToString(nTotalWeight));
-        WriteTimestampedLogEntry("Rolled = " + IntToString(nRolledWeight));
-    }
-    int nAssignedIndex = -1;
-    for (i=1; i<=nNumLootRecievers; i++)
-    {
-        int nWeight = GetLocalArrayInt(OBJECT_SELF, "LootWeights", i);
-        nRolledWeight -= nWeight;
-        if (LOOT_OWING_DEBUG)
-        {
-            WriteTimestampedLogEntry("Index = " + IntToString(i) + " subtracted " + IntToString(nWeight) + "; now rolled = " + IntToString(nRolledWeight));
-        }
-        if (nRolledWeight < 0)
-        {
-            nAssignedIndex = i;
-            break;
-        }
-    }
-    if (LOOT_OWING_DEBUG)
-    {
-        WriteTimestampedLogEntry("Assigned index = " + IntToString(nAssignedIndex));
-    }
-    // Convert back to an object to return
-    if (nAssignedIndex <= Party.PlayerSize)
-    {
-        oRecipient = GetLocalArrayObject(OBJECT_SELF, "Players", nAssignedIndex);
-    }
-    else
-    {
-        oRecipient = GetLocalArrayObject(OBJECT_SELF, "Henchmans", nAssignedIndex - Party.PlayerSize);
-    }
-    // Update gold owings
-    // I guess the best way to do this is to just subtract (item gold value/(party size-1)) from everyone else's owing
-    // to the person who got it
-    
-    // This logic will turn into a divide by zero if solo
-    if (nNumLootRecievers > 1)
-    {
-        int nSubtraction = -1*(nItemValue/(nNumLootRecievers-1));
-        for (i=1; i<=nNumLootRecievers; i++)
-        {
-            object oNonRecipient;
-            if (i <= Party.PlayerSize)
-            {
-                oNonRecipient = GetLocalArrayObject(OBJECT_SELF, "Players", i);
-            }
-            else
-            {
-                oNonRecipient = GetLocalArrayObject(OBJECT_SELF, "Henchmans", i - Party.PlayerSize);
-            }
-            if (i == nAssignedIndex)
-            {
-                continue;
-            }
-            AdjustOwedGoldValue(oRecipient, oNonRecipient, nSubtraction);
-        }
-    }
-    if (LOOT_OWING_DEBUG)
-    {
-        WriteTimestampedLogEntry("Assigned " + GetName(oItem) + " to " + GetName(oRecipient));
-    }
-    return oRecipient;
-}
-
 void main()
 {
 // this should never trigger on a PC, nunless it's DM-possessed
@@ -686,7 +508,7 @@ void main()
     }
 
 // Calculate how many items to make, and to which player it goes to
-   int nNumItems = 0;
+   int nItem1, nItem2, nItem3;
 
    int nItemsRoll = d100();
 
@@ -700,16 +522,28 @@ void main()
 
    if (nItemsRoll <= nChanceThree)
    {
-       nNumItems = 3;
+       nItem3 = Random(nTotalSize)+1;
+       nItem2 = Random(nTotalSize)+1;
+       nItem1 = Random(nTotalSize)+1;
    }
    else if (nItemsRoll <= nChanceTwo)
    {
-       nNumItems = 2;
+       nItem2 = Random(nTotalSize)+1;
+       nItem1 = Random(nTotalSize)+1;
    }
    else if ((nItemsRoll <= nChanceOne) || (bSemiBoss == 1))
    {
-       nNumItems = 1;
+       nItem1 = Random(nTotalSize)+1;
    }
+
+   if (nItem1 > 0)
+    SendDebugMessage("Item 1: "+IntToString(nItem1));
+
+   if (nItem2 > 0)
+    SendDebugMessage("Item 2: "+IntToString(nItem2));
+
+   if (nItem3 > 0)
+    SendDebugMessage("Item 3: "+IntToString(nItem3));
 
     if (ShouldDebugLoot())
     {
@@ -728,7 +562,9 @@ void main()
         // Because we just calculated the correct expected amount of items
         // It will mean that the actual items created will not be correct though, but that's a small price to pay for science
         // plus if you can run this you can just warp to the treasure area and loot whatever you want anyway
-        nNumItems = 1;
+        nItem1 = 1;
+        nItem2 = 0;
+        nItem3 = 0;
         bNoTreasure = FALSE;
     }
 
@@ -747,41 +583,6 @@ void main()
    }
    
    float fXP = GetPartyXPValue(OBJECT_SELF, bAmbush, Party.AverageLevel, Party.TotalSize, fMultiplier);
-   
-   
-// =============================
-// ASSIGN ITEMS TO PARTY MEMBERS
-// =============================
-   
-   // The items we are about to drop as loot
-   object oItem1;
-   object oItem2;
-   object oItem3;
-   
-   // For storing which party member is getting the corresponding item
-   object oItem1AssignedTo;
-   object oItem2AssignedTo;
-   object oItem3AssignedTo;
-   
-   if (!bNoTreasure)
-   {
-       if (nNumItems > 0)
-       {
-           oItem1 = SelectLoot(OBJECT_SELF);
-           oItem1AssignedTo = DeterminePartyMemberThatGetsItem(oItem1);
-       }
-       if (nNumItems > 1)
-       {
-           oItem2 = SelectLoot(OBJECT_SELF);
-           oItem2AssignedTo = DeterminePartyMemberThatGetsItem(oItem2);
-       }
-       if (nNumItems > 2)
-       {
-           oItem3 = SelectLoot(OBJECT_SELF);
-           oItem3AssignedTo = DeterminePartyMemberThatGetsItem(oItem3);
-       }
-       
-   }
 
 // =========================
 // START LOOP
@@ -815,18 +616,17 @@ void main()
             object oQuest = CreateItemOnObject(sQuestItemResRef, oPersonalLoot, 1, "quest");
             SetName(oQuest, QUEST_ITEM_NAME_COLOR + GetName(oQuest) + "</c>");
         }
-        
-        
+
         if (bNoTreasure == FALSE)
         {
            SetLocalInt(oPersonalLoot, "cr", GetLocalInt(oContainer, "cr"));
            SetLocalInt(oPersonalLoot, "area_cr", GetLocalInt(oContainer, "area_cr"));
 
-           if (oPC == oItem1AssignedTo) CopyTierItemToContainer(oItem1, oPersonalLoot);
-           if (oPC == oItem2AssignedTo) CopyTierItemToContainer(oItem2, oPersonalLoot);
-           if (oPC == oItem3AssignedTo) CopyTierItemToContainer(oItem3, oPersonalLoot);
+           if (nNth == nItem1) GenerateLoot(oPersonalLoot);
+           if (nNth == nItem2) GenerateLoot(oPersonalLoot);
+           if (nNth == nItem3) GenerateLoot(oPersonalLoot);
         }
-        
+
 
 // distribute gold evenly to all
         if (nGold > 0)
@@ -878,20 +678,21 @@ void main()
                SetLocalInt(oHenchman, "cr", GetLocalInt(oContainer, "cr"));
                SetLocalInt(oHenchman, "area_cr", GetLocalInt(oContainer, "area_cr"));
                object oMerchant = GetLocalObject(oHenchman, "merchant");
+               object oItem1, oItem2, oItem3;
 // assumed to be out of bounds (henchman)
-               if (oHenchman == oItem1AssignedTo)
+               if (Party.PlayerSize+nNth == nItem1)
                {
-                   oItem1 = CopyTierItemToContainer(oItem1, oMerchant);
+                   oItem1 = GenerateLoot(oContainer, oMerchant);
                    DetermineItem(oItem1, oMerchant, oHenchman, nNth);
                }
-               if (oHenchman == oItem2AssignedTo)
+               if (Party.PlayerSize+nNth == nItem2)
                {
-                   oItem2 = CopyTierItemToContainer(oItem2, oMerchant);
+                   oItem2 = GenerateLoot(oContainer, oMerchant);
                    DetermineItem(oItem2, oMerchant, oHenchman, nNth);
                }
-               if (oHenchman == oItem3AssignedTo)
+               if (Party.PlayerSize+nNth == nItem3)
                {
-                   oItem3 = CopyTierItemToContainer(oItem3, oMerchant);
+                   oItem3 = GenerateLoot(oContainer, oMerchant);
                    DetermineItem(oItem3, oMerchant, oHenchman, nNth);
                }
 


### PR DESCRIPTION
I can't see any reason why this should be causing the dialogue-stuck NPC bug, but try reverting to see what happens.

This reverts commit 6d7a54e3d42bb37dbdb848ebeea87ecfea53ed12.