### PR TITLE
Fix Mary becoming generic commoner, Jhareg dialogue fixes

### DIFF
--- a/src/dlg/belial.dlg.json
+++ b/src/dlg/belial.dlg.json
@@ -690,7 +690,7 @@
               "__struct_id": 1,
               "Active": {
                 "type": "resref",
-                "value": "nw_d2_intn"
+                "value": ""
               },
               "ConditionParams": {
                 "type": "list",

--- a/src/dlg/guardian.dlg.json
+++ b/src/dlg/guardian.dlg.json
@@ -694,7 +694,7 @@
         },
         "Script": {
           "type": "resref",
-          "value": ""
+          "value": "dlg_q_adv1"
         },
         "Sound": {
           "type": "resref",
@@ -2668,7 +2668,7 @@
         },
         "Script": {
           "type": "resref",
-          "value": "m2q3h_guardiana6"
+          "value": ""
         },
         "Sound": {
           "type": "resref",
@@ -3183,7 +3183,7 @@
         },
         "Script": {
           "type": "resref",
-          "value": "m2q3h_guardiana7"
+          "value": ""
         },
         "Sound": {
           "type": "resref",
@@ -3514,7 +3514,7 @@
         },
         "Script": {
           "type": "resref",
-          "value": "m2q3h_guardiaa13"
+          "value": ""
         },
         "Sound": {
           "type": "resref",
@@ -4018,7 +4018,7 @@
         },
         "Script": {
           "type": "resref",
-          "value": "m2q3h_guardiaa12"
+          "value": ""
         },
         "Sound": {
           "type": "resref",
@@ -9528,7 +9528,7 @@
         },
         "Script": {
           "type": "resref",
-          "value": "m2q3h_guardiana8"
+          "value": ""
         },
         "Sound": {
           "type": "resref",
@@ -11993,7 +11993,7 @@
         },
         "Script": {
           "type": "resref",
-          "value": "m2q3h_guardiana9"
+          "value": ""
         },
         "Sound": {
           "type": "resref",

--- a/src/dlg/jharegk_book.dlg.json
+++ b/src/dlg/jharegk_book.dlg.json
@@ -130,11 +130,7 @@
         },
         "Quest": {
           "type": "cexostring",
-          "value": "m2q3E_Belial"
-        },
-        "QuestEntry": {
-          "type": "dword",
-          "value": 10
+          "value": ""
         },
         "RepliesList": {
           "type": "list",

--- a/src/git/hr_south2.git.json
+++ b/src/git/hr_south2.git.json
@@ -33275,7 +33275,7 @@
         },
         "IsImmortal": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "IsPC": {
           "type": "byte",


### PR DESCRIPTION
Added immortal flag to Mary so she doesn't get replaced with a noname commoner who gives no quests.
When talking to the Jhareg Guardian for the first time, picking "Get to the point, will you?" now correctly updates the quest stage.
Removed an OC journal entry key that would be picked up when reading Karlat's summoning tome.