### PR TITLE
Treasure maps buyable from henchmen

### DIFF
--- a/src/nss/area_refresh.nss
+++ b/src/nss/area_refresh.nss
@@ -76,7 +76,7 @@ void main()
 // ==============================
 // clean up old treasures
     int nOldTreasure;
-    for (nOldTreasure = 0; nOldTreasure < 50; nOldTreasure++)
+    for (nOldTreasure = 0; nOldTreasure < 100; nOldTreasure++)
         DestroyObject(GetLocalObject(OBJECT_SELF, "treasure"+IntToString(nOldTreasure)));
 
      float fAreaSize = IntToFloat(GetAreaSize(AREA_HEIGHT, OBJECT_SELF)*GetAreaSize(AREA_WIDTH, OBJECT_SELF));

--- a/src/nss/inc_treasuremap.nss
+++ b/src/nss/inc_treasuremap.nss
@@ -1505,7 +1505,7 @@ int GetTreasureMapGoldValue(int nACR)
     else if (nACR >= 6) { nValue += (nACR * 2); }
 
     // Then multiply up by a bit...
-    nValue *= 3;
+    nValue *= 4;
     return nValue;
 }
 

--- a/src/nss/party_credit.nss
+++ b/src/nss/party_credit.nss
@@ -194,14 +194,7 @@ void SendLootMessage(object oHench, object oItem, string sName="")
 
 void DetermineItem(object oItem, object oMerchant, object oHench, int nNth)
 {
-   // Henchmen keep these items for themselves
-   if (GetTag(oItem) == "treasuremap")
-   {
-       string sName = GetName(oItem);
-       AssignCommand(GetModule(), DelayCommand(IntToFloat(nNth)+1.0+(IntToFloat(d8())*0.1), SendLootMessage(oHench, oItem, sName)));
-       DestroyObject(oItem);
-   }
-   else if (GetBaseItemType(oItem) == BASE_ITEM_POTIONS)
+   if (GetBaseItemType(oItem) == BASE_ITEM_POTIONS)
    {
        object oNewItem = CopyItem(oItem, oHench, TRUE);
        SetDroppableFlag(oNewItem, FALSE);


### PR DESCRIPTION
Treasure maps can be bought from henchmen when they get assigned them.
Increased the treasure map price by ~30%.
The Valley of the Dead should now clear all treasures on refresh, instead of just placing new ones on top of old ones in some places around the eastern side of the area.