### PR TITLE
Small fixes - mostly werewolf

### DIFF
--- a/src/git/highcliff_inn.git.json
+++ b/src/git/highcliff_inn.git.json
@@ -853,6 +853,82 @@
                 "type": "resref",
                 "value": "nw_cloth022"
               },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 39
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -1592,6 +1668,82 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "nw_cloth022"
+              },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 39
               },
               "XOrientation": {
                 "type": "float",
@@ -2333,6 +2485,82 @@
                 "type": "resref",
                 "value": "nw_cloth022"
               },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 39
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -3072,6 +3300,82 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "nw_cloth022"
+              },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 39
               },
               "XOrientation": {
                 "type": "float",
@@ -3813,6 +4117,82 @@
                 "type": "resref",
                 "value": "nw_cloth022"
               },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 39
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -4552,6 +4932,82 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "nw_cloth022"
+              },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 39
               },
               "XOrientation": {
                 "type": "float",
@@ -5293,6 +5749,82 @@
                 "type": "resref",
                 "value": "nw_cloth022"
               },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 39
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -6032,6 +6564,82 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "nw_cloth022"
+              },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 39
               },
               "XOrientation": {
                 "type": "float",
@@ -6773,6 +7381,82 @@
                 "type": "resref",
                 "value": "nw_cloth022"
               },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 39
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -7512,6 +8196,82 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "nw_cloth022"
+              },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 16
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 39
               },
               "XOrientation": {
                 "type": "float",
@@ -8253,6 +9013,82 @@
                 "type": "resref",
                 "value": "nw_aarcl004"
               },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 10
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 12
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 4
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 5
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 4
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 17
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 19
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 5
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 12
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 4
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 5
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 4
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 17
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 19
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 5
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 32
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -8349,6 +9185,18 @@
                 "type": "resref",
                 "value": "nw_wswls001"
               },
+              "xModelPart1": {
+                "type": "word",
+                "value": 61
+              },
+              "xModelPart2": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart3": {
+                "type": "word",
+                "value": 11
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -8436,6 +9284,10 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "nw_ashlw001"
+              },
+              "xModelPart1": {
+                "type": "word",
+                "value": 11
               },
               "XOrientation": {
                 "type": "float",
@@ -8690,6 +9542,18 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "cre_inflbow"
+              },
+              "xModelPart1": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart2": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart3": {
+                "type": "word",
+                "value": 11
               },
               "XOrientation": {
                 "type": "float",
@@ -9376,6 +10240,82 @@
                 "type": "resref",
                 "value": "nw_aarcl004"
               },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 10
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 12
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 4
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 5
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 4
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 17
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 19
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 5
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 12
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 4
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 5
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 4
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 17
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 19
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 5
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 32
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -9472,6 +10412,18 @@
                 "type": "resref",
                 "value": "nw_wswls001"
               },
+              "xModelPart1": {
+                "type": "word",
+                "value": 61
+              },
+              "xModelPart2": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart3": {
+                "type": "word",
+                "value": 11
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -9559,6 +10511,10 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "nw_ashlw001"
+              },
+              "xModelPart1": {
+                "type": "word",
+                "value": 11
               },
               "XOrientation": {
                 "type": "float",
@@ -9813,6 +10769,18 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "cre_inflbow"
+              },
+              "xModelPart1": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart2": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart3": {
+                "type": "word",
+                "value": 11
               },
               "XOrientation": {
                 "type": "float",
@@ -10499,6 +11467,82 @@
                 "type": "resref",
                 "value": "nw_aarcl004"
               },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 10
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 12
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 4
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 5
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 4
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 17
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 19
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 5
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 12
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 4
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 5
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 4
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 17
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 19
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 5
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 32
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -10595,6 +11639,18 @@
                 "type": "resref",
                 "value": "nw_wswls001"
               },
+              "xModelPart1": {
+                "type": "word",
+                "value": 61
+              },
+              "xModelPart2": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart3": {
+                "type": "word",
+                "value": 11
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -10682,6 +11738,10 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "nw_ashlw001"
+              },
+              "xModelPart1": {
+                "type": "word",
+                "value": 11
               },
               "XOrientation": {
                 "type": "float",
@@ -10936,6 +11996,18 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "cre_inflbow"
+              },
+              "xModelPart1": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart2": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart3": {
+                "type": "word",
+                "value": 11
               },
               "XOrientation": {
                 "type": "float",
@@ -11783,6 +12855,82 @@
                 "type": "resref",
                 "value": "m2_cloth_010"
               },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 12
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 8
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 8
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 9
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 25
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 8
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 8
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 9
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 3
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -11882,6 +13030,18 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "nw_wswss001"
+              },
+              "xModelPart1": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart2": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart3": {
+                "type": "word",
+                "value": 11
               },
               "XOrientation": {
                 "type": "float",
@@ -12768,6 +13928,51 @@
                 "type": "cexostring",
                 "value": "weapon310"
               }
+            },
+            {
+              "__struct_id": 0,
+              "Name": {
+                "type": "cexostring",
+                "value": "quest3_prereq1"
+              },
+              "Type": {
+                "type": "dword",
+                "value": 3
+              },
+              "Value": {
+                "type": "cexostring",
+                "value": "02_q_werewolf"
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Name": {
+                "type": "cexostring",
+                "value": "quest4_prereq1"
+              },
+              "Type": {
+                "type": "dword",
+                "value": 3
+              },
+              "Value": {
+                "type": "cexostring",
+                "value": "02_q_werewolf"
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Name": {
+                "type": "cexostring",
+                "value": "quest5_prereq1"
+              },
+              "Type": {
+                "type": "dword",
+                "value": 3
+              },
+              "Value": {
+                "type": "cexostring",
+                "value": "02_q_werewolf"
+              }
             }
           ]
         },
@@ -12786,6 +13991,82 @@
         "Wis": {
           "type": "byte",
           "value": 8
+        },
+        "xAppearance_Head": {
+          "type": "word",
+          "value": 16
+        },
+        "xArmorPart_RFoot": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_Belt": {
+          "type": "word",
+          "value": 0
+        },
+        "xBodyPart_LBicep": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_LFArm": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_LFoot": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_LHand": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_LShin": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_LShoul": {
+          "type": "word",
+          "value": 0
+        },
+        "xBodyPart_LThigh": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_Neck": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_Pelvis": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_RBicep": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_RFArm": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_RHand": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_RShin": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_RShoul": {
+          "type": "word",
+          "value": 0
+        },
+        "xBodyPart_RThigh": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_Torso": {
+          "type": "word",
+          "value": 1
         },
         "XOrientation": {
           "type": "float",

--- a/src/git/hr_eisen.git.json
+++ b/src/git/hr_eisen.git.json
@@ -355,6 +355,18 @@
                 "type": "resref",
                 "value": "nw_wswss001"
               },
+              "xModelPart1": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart2": {
+                "type": "word",
+                "value": 11
+              },
+              "xModelPart3": {
+                "type": "word",
+                "value": 11
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -733,6 +745,21 @@
                 "type": "cexostring",
                 "value": "02_q_werewolf_urth"
               }
+            },
+            {
+              "__struct_id": 0,
+              "Name": {
+                "type": "cexostring",
+                "value": "quest1_nohighlight"
+              },
+              "Type": {
+                "type": "dword",
+                "value": 1
+              },
+              "Value": {
+                "type": "int",
+                "value": 1
+              }
             }
           ]
         },
@@ -1009,6 +1036,82 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "nw_cloth026"
+              },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 14
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 6
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 14
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 3
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 39
               },
               "XOrientation": {
                 "type": "float",
@@ -1435,6 +1538,21 @@
                 "type": "cexostring",
                 "value": "02_q_werewolf_urth"
               }
+            },
+            {
+              "__struct_id": 0,
+              "Name": {
+                "type": "cexostring",
+                "value": "quest1_nohighlight"
+              },
+              "Type": {
+                "type": "dword",
+                "value": 1
+              },
+              "Value": {
+                "type": "int",
+                "value": 1
+              }
             }
           ]
         },
@@ -1648,6 +1766,10 @@
                 "type": "resref",
                 "value": "nw_it_crewpsp010"
               },
+              "xModelPart1": {
+                "type": "word",
+                "value": 1
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -1768,6 +1890,10 @@
                 "type": "resref",
                 "value": "nw_it_crewpsp010"
               },
+              "xModelPart1": {
+                "type": "word",
+                "value": 1
+              },
               "XOrientation": {
                 "type": "float",
                 "value": 0.0
@@ -1887,6 +2013,10 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "nw_it_crewps003"
+              },
+              "xModelPart1": {
+                "type": "word",
+                "value": 1
               },
               "XOrientation": {
                 "type": "float",
@@ -2164,6 +2294,10 @@
               "TemplateResRef": {
                 "type": "resref",
                 "value": "cre_qwerewolfsk"
+              },
+              "xModelPart1": {
+                "type": "word",
+                "value": 1
               },
               "XOrientation": {
                 "type": "float",

--- a/src/nss/70_featfix.nss
+++ b/src/nss/70_featfix.nss
@@ -47,10 +47,13 @@ void main()
     }
     if(darkvision)
     {
-        ApplyEffectToObject(DURATION_TYPE_EQUIPPED,TagEffect(NWNXPatch_SetEffectTrueType(EffectVisualEffect(2),69),"EC_FEATFIX"),oPC);
+        // EffectVisualEffect(2) is VFX_DUR_ENTANGLE, aka why people keep logging in and getting planted
+        //ApplyEffectToObject(DURATION_TYPE_EQUIPPED,TagEffect(NWNXPatch_SetEffectTrueType(EffectVisualEffect(2),69),"EC_FEATFIX"),oPC);
     }
     if(lowvision)
     {
-        ApplyEffectToObject(DURATION_TYPE_EQUIPPED,TagEffect(NWNXPatch_SetEffectTrueType(EffectVisualEffect(1),69),"EC_FEATFIX"),oPC);
+        // 1 is VFX_DUR_DARKNESS, unsure what this is meant to do but it sounds like it makes a dark area around you
+        // ... why?
+        //ApplyEffectToObject(DURATION_TYPE_EQUIPPED,TagEffect(NWNXPatch_SetEffectTrueType(EffectVisualEffect(1),69),"EC_FEATFIX"),oPC);
     }
 }

--- a/src/nss/hb_qwerewolf.nss
+++ b/src/nss/hb_qwerewolf.nss
@@ -11,8 +11,8 @@ void main()
 // we don't want to use the limbo feature, as I think it may interfere with creature clean up when an area resets
     if (!GetIsAreaInterior(oArea) && GetIsDay())
     {
-        ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectCutsceneGhost(), OBJECT_SELF);
-        ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectCutsceneParalyze(), OBJECT_SELF);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, UnyieldingEffect(EffectCutsceneGhost()), OBJECT_SELF);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, UnyieldingEffect(  EffectCutsceneParalyze()), OBJECT_SELF);
         NWNX_Visibility_SetVisibilityOverride(OBJECT_INVALID, OBJECT_SELF, NWNX_VISIBILITY_HIDDEN);
         SetPlotFlag(OBJECT_SELF, TRUE);
     }
@@ -22,13 +22,17 @@ void main()
 
         while (GetIsEffectValid(eEffect))
         {
-            if (GetEffectType(eEffect) == EFFECT_TYPE_CUTSCENEGHOST) RemoveEffect(OBJECT_SELF, eEffect);
-            if (GetEffectType(eEffect) == EFFECT_TYPE_CUTSCENE_PARALYZE) RemoveEffect(OBJECT_SELF, eEffect);
-
+            int nType = GetEffectType(eEffect);
+            if (nType == EFFECT_TYPE_CUTSCENEGHOST || nType == EFFECT_TYPE_CUTSCENE_PARALYZE)
+            {
+                // Effect removal during an effect loop has caused issues in the past, better to wait until after the script completes to do it
+                DelayCommand(0.0, RemoveEffect(OBJECT_SELF, eEffect));
+            }
+            
             eEffect = GetNextEffect(OBJECT_SELF);
         }
 
-        NWNX_Visibility_SetVisibilityOverride(OBJECT_INVALID, OBJECT_SELF, NWNX_VISIBILITY_VISIBLE);
+        NWNX_Visibility_SetVisibilityOverride(OBJECT_INVALID, OBJECT_SELF, NWNX_VISIBILITY_DEFAULT);
         SetPlotFlag(OBJECT_SELF, FALSE);
     }
 }

--- a/src/nss/inc_treasuremap.nss
+++ b/src/nss/inc_treasuremap.nss
@@ -1118,13 +1118,19 @@ void DisplayTreasureMapUI(object oPC, int nPuzzleID, int nACR, object oMap=OBJEC
     SetLocalObject(oPC, "opened_treasuremap", oMap);
     int nScale = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
     float fScale = IntToFloat(nScale)/100.0;
-
     float fGeometryRectPos = -1.0;
-    if (nScale != 100)
+    // prior to 8193.35 drawlists were not affected by UI scaling
+    // putting things in the top left corner of the screen was the only way to see what was going on.
+    if (GetPlayerBuildVersionMajor(oPC) == 8193 && GetPlayerBuildVersionMinor(oPC) < 35)
     {
-        SendMessageToPC(oPC, "Due to an engine bug the map may not display correctly with your UI scaling. This should be fixed in a future NWN update, but keeping the map close to the top left of the screen should help with this.");
-        fGeometryRectPos = 0.0;
+        if (nScale != 100)
+        {
+            SendMessageToPC(oPC, "Due to an engine bug the map may not display correctly with your UI scaling. This should be fixed in a future NWN update, but keeping the map close to the top left of the screen should help with this.");
+            fGeometryRectPos = 0.0;
+        }
     }
+    
+    
     // "-" may not be legal for sqlite, I don't want to find out what happens then or if it's possible to do something
     // bad to the db in this case
     if (nACR < 0)


### PR DESCRIPTION
Fixed logging in giving entangle effects until rest
Hopefully fixed invisible werewolves not being paralyzed during the day
Fixed quest NPC highlights for the werewolf quest
Removed NUI drawlist workaround for people using UI scaling. These people should no longer have maps open in the top left to try to minimise that
Ran reseed, only notable change was that Luskan gate's tiles changed which might have changed maps in that area