### PR TITLE
Using commandline passwords for DM and Players

### DIFF
--- a/src/nss/mod_check_init.nss
+++ b/src/nss/mod_check_init.nss
@@ -11,8 +11,8 @@ void main()
     if (GetLocalInt(oModule, "treasure_ready") == 1)
     {
         NWNX_Util_SetInstructionLimit(-1);
-        NWNX_Administration_ClearPlayerPassword();
-        NWNX_Administration_SetDMPassword(Get2DAString("env", "Value", 3));
+        NWNX_Administration_SetPlayerPassword(GetLocalString(GetModule(), "PlayerPassword"));
+        NWNX_Administration_SetDMPassword(GetLocalString(GetModule(), "DMPassword"));
         SetEventScript(oModule, EVENT_SCRIPT_MODULE_ON_HEARTBEAT, "on_mod_heartb");
         ServerWebhook("The Frozen North is ready!", "The Frozen North server is ready for players to login.");
     }

--- a/src/nss/on_mod_load.nss
+++ b/src/nss/on_mod_load.nss
@@ -292,6 +292,10 @@ void main()
     NWNX_Administration_SetPlayOption(NWNX_ADMINISTRATION_OPTION_PVP_SETTING, 2);
     NWNX_Administration_SetPlayOption(NWNX_ADMINISTRATION_OPTION_VALIDATE_SPELLS, TRUE);
 
+// Save initial passwords for use after everything is initialized and ready
+    SetLocalString(GetModule(), "PlayerPassword", NWNX_Administration_GetPlayerPassword());
+    SetLocalString(GetModule(), "DMPassword", NWNX_Administration_GetDMPassword());
+
 // Set a password until everything is initialized and ready
     NWNX_Administration_SetPlayerPassword(GetRandomUUID());
 

--- a/templates/env.2da
+++ b/templates/env.2da
@@ -3,5 +3,4 @@
          Label		Value                                       
 0        AdminCDKey <ADMIN CD KEY>
 1        AdminName  <ADMIN PLAYER NAME>
-2        DiscordLog <DISCORD WEBHOOK>                                    
-3        DMPassword <DM PASSWORD>                                                                 
+2        DiscordLog <DISCORD WEBHOOK>


### PR DESCRIPTION
Both DM and Player passwords taken from commandline and restored after the server is initialized. Allows private servers instead of an always empty password.

I tested both passwords were set correctly, and I also tested that an empty password didn't break anything.