### PR TITLE
Minor fixes/omissions

### DIFF
--- a/src/nss/create_ambush.nss
+++ b/src/nss/create_ambush.nss
@@ -195,8 +195,8 @@ void main()
 
     // Small chance for adventurer assassins instead
     // Testing this at full odds is an exercise in insanity
-    //if (Random(100) < 3)
-    if (1)
+    if (Random(100) < 3)
+    //if (1)
     {
         bMakeRegularAmbush = !CreateAdventurerAmbush(GetLocation(OBJECT_SELF), oPC);
     }

--- a/src/nss/inc_rand_feat.nss
+++ b/src/nss/inc_rand_feat.nss
@@ -204,7 +204,15 @@ int _EvaluateRandomFeat_Melee(object oCreature, int nFeat)
     if (nFeat == FEAT_BLIND_FIGHT) { return 60; }
     if (nFeat == FEAT_CALLED_SHOT) { return 30; }
     if (nFeat == FEAT_CLEAVE) {  return 60; }
-    if (nFeat == FEAT_CIRCLE_KICK) { return 150; }
+    if (nFeat == FEAT_CIRCLE_KICK)
+    {
+        // Things like Ranger 11 Monk 1 adventurers really want kamas and to not waste a feat on this
+        if (GetLevelByClass(CLASS_TYPE_MONK, oCreature) * 4 >= GetHitDice(oCreature))
+        {
+            return 150;
+        }
+        return 0;
+    }
     if (nFeat == FEAT_DISARM) { return 40; }
     if (nFeat == FEAT_DODGE) { return 30; }
     if (nFeat == FEAT_EXPERTISE) { return 40; }

--- a/src/nss/pc_dth_penalty.nss
+++ b/src/nss/pc_dth_penalty.nss
@@ -9,5 +9,6 @@ void main()
     {
         SetXP(oPlayer, GetXPOnRespawn(oPlayer));
         TakeGoldFromCreature(GetGoldLossOnRespawn(oPlayer), oPlayer, TRUE);
+        UpdateXPBarUI(oPlayer);
     }
 }

--- a/src/nss/treasuremap_evt.nss
+++ b/src/nss/treasuremap_evt.nss
@@ -20,7 +20,14 @@ void main()
         }
         string sNote = JsonGetString(NuiGetBind(oPC, nToken, "tmap_notes"));
         SetLocalString(oMap, "treasuremap_notes", sNote);
-        SetName(oMap, "Treasure Map - " + sNote);
+        if (sNote != "")
+        {
+            SetName(oMap, "Treasure Map - " + sNote);
+        }
+        else
+        {
+            SetName(oMap, "Treasure Map");
+        }
     }
     if (sElement == "digbutton" && sEvent == "click")
     {


### PR DESCRIPTION
Fixed the resting surprise incorrectly being 100% instead of 3%, because I am bad at turning off testing code.
Fixed the XP bar not updating when losing XP due to respawning.
Fixed digging for treasure via a map UI causing (harmless) sqlite errors if you have maps that have never been viewed in your inventory.
Fixed viewing treasure maps without notes renaming the map to "Treasure Map - ". Viewing affected maps again should revert them to normal.
Adventurers that are unlikely to fight unarmed will no longer pick Circle Kick.