### PR TITLE
Small Tweaks/Fixes

### DIFF
--- a/src/git/core_blade.git.json
+++ b/src/git/core_blade.git.json
@@ -27424,6 +27424,21 @@
           "type": "int",
           "value": 1
         }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "restxp"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
       }
     ]
   },

--- a/src/git/ud_hotenowgatbld.git.json
+++ b/src/git/ud_hotenowgatbld.git.json
@@ -41244,15 +41244,15 @@
         },
         "X": {
           "type": "float",
-          "value": 74.9632
+          "value": 76.7516
         },
         "Y": {
           "type": "float",
-          "value": 85.0703
+          "value": 86.29259999999999
         },
         "Z": {
           "type": "float",
-          "value": 0.0
+          "value": -0.0
         }
       },
       {

--- a/src/nss/hen_ondeath.nss
+++ b/src/nss/hen_ondeath.nss
@@ -20,10 +20,14 @@ void main()
 
     SetLocalInt(OBJECT_SELF, "times_died", GetLocalInt(OBJECT_SELF, "times_died")+1);
 
-    string sText = "*Your henchman has died*";
+    string sText = "*" + GetName(OBJECT_SELF) + " has died*";
 
     if (!IsCreatureRevivable(OBJECT_SELF))
-        sText = "*Your henchman has died, and can only be revived by Raise Dead*";
+    {
+        sText = "*" + GetName(OBJECT_SELF) + " has died, and can only be revived by Raise Dead*";
+        // Allow selecting henchmen to cast raise dead on them
+        SetIsDestroyable(TRUE, TRUE, TRUE);
+    }
 
 
     FloatingTextStringOnCreature(sText, GetMaster(OBJECT_SELF), FALSE);

--- a/src/nss/inc_loot.nss
+++ b/src/nss/inc_loot.nss
@@ -425,10 +425,13 @@ string DetermineTier(int iCR, int iAreaCR, string sType = "", float fWeightExpon
     else if (sType == "Scrolls") { fWeightExponent += SCROLL_CONSUMABLE_QUALITY_MODIFIER; }
 
     fT1Weight = pow(fT1Weight, fWeightExponent);
-    fT2Weight = pow(fT2Weight, fWeightExponent);
-    fT3Weight = pow(fT3Weight, fWeightExponent);
-    fT4Weight = pow(fT4Weight, fWeightExponent);
-    fT5Weight = pow(fT5Weight, fWeightExponent);
+    // Don't raise these to a power if they were zero to start with
+    // If the exponent is also zero, then 0.0^0.0 = 1
+    // and items that aren't supposed to be possible at low ACR suddenly become possible!
+    if (fT2Weight > 0.0) { fT2Weight = pow(fT2Weight, fWeightExponent); }
+    if (fT3Weight > 0.0) { fT3Weight = pow(fT3Weight, fWeightExponent); }
+    if (fT4Weight > 0.0) { fT4Weight = pow(fT4Weight, fWeightExponent); }
+    if (fT5Weight > 0.0) { fT5Weight = pow(fT5Weight, fWeightExponent); }
 
     int nT1Weight = FloatToInt(fT1Weight * 1000.0);
     int nT2Weight = FloatToInt(fT2Weight * 1000.0);

--- a/src/nss/inc_webhook.nss
+++ b/src/nss/inc_webhook.nss
@@ -320,17 +320,16 @@ void DeathWebhook(object oPC, object oKiller, int bPetrified = FALSE)
     }
     else
     {
-       sName = "**"+sName+"**";
        if (GetIsObjectValid(GetMaster(oKiller)))
        {
             int nAssociateType = GetAssociateType(oKiller);
             if (nAssociateType == ASSOCIATE_TYPE_FAMILIAR || nAssociateType == ASSOCIATE_TYPE_ANIMALCOMPANION || nAssociateType == ASSOCIATE_TYPE_SUMMONED)
             {
-                sName = "**" + GetName(GetMaster(oKiller)) + "'s " + GetName(oKiller) + "**";
+                sName = GetName(GetMaster(oKiller)) + "'s " + GetName(oKiller);
             }
        }
     }
-    stMessage.sDescription = "**"+GetName(oPC)+"** was "+sAction+" by "+sName+".";
+    stMessage.sDescription = "**"+GetName(oPC)+"** was "+sAction+" by **"+sName+"**.";
 
     //stMessage.sFooterText = GetName(GetModule());
     //stMessage.iTimestamp = SQLite_GetTimeStamp();

--- a/src/nss/nw_i0_spells.nss
+++ b/src/nss/nw_i0_spells.nss
@@ -233,15 +233,15 @@ void DoSpellBreach(object oTarget, int nTotal, int nSR, int nSpellId = -1)
         }
         if(nIdx > 0)//1.72: breach spells now prints feedback which spells were breached
         {
-            sFeedback = "<c?w?>"+GetStringByStrRef(StringToInt(Get2DAString("spells","Name",nSpellId)))+"</c> : ";
+            sFeedback = "<c\xccw\xfe>"+GetStringByStrRef(StringToInt(Get2DAString("spells","Name",nSpellId)))+"</c> : ";
             sSpellsRemoved = GetStringLeft(sSpellsRemoved,GetStringLength(sSpellsRemoved)-2)+"</c>";
             if(OBJECT_SELF != oTarget && GetIsPC(OBJECT_SELF))
             {
-                SendMessageToPC(OBJECT_SELF,sFeedback+"<c??>"+GetName(oTarget)+"</c> : <c?w?>"+sSpellsRemoved);
+                SendMessageToPC(OBJECT_SELF,sFeedback+"<\xcc\x99\xcc>"+GetName(oTarget)+"</c> : <c\x63w\x77>"+sSpellsRemoved);
             }
             if(GetIsPC(oTarget))
             {
-                SendMessageToPC(oTarget,sFeedback+"<c???>"+GetName(oTarget)+"</c> : <c?w?>"+sSpellsRemoved);
+                SendMessageToPC(oTarget,sFeedback+"<c\x9b\xfe\xfe>"+GetName(oTarget)+"</c> : <c\xccw\xfe>"+sSpellsRemoved);
             }
         }
         effect eLink = EffectLinkEffects(eDur, eSR);
@@ -546,7 +546,7 @@ int bDFBorGlyph = spell.Id == SPELL_DELAYED_BLAST_FIREBALL || spell.Id == SPELL_
  string sFeedback = GetStringByStrRef(8342);//this will work pretty well for singleplayer
  sFeedback = GetStringLeft(sFeedback,GetStringLength(sFeedback)-10);//but if would someone with non-english language
  sFeedback = GetStringRight(sFeedback,GetStringLength(sFeedback)-10);//played english server, then this immunity
- sFeedback = "<c???>"+GetName(oTarget)+"</c> <c??>"+sFeedback+" "+GetStringByStrRef(8344)+"</c>";//feedback will be
+ sFeedback = "<c\x9b\xfe\xfe>"+GetName(oTarget)+"</c> <c\xcd\x7f\xfe>"+sFeedback+" "+GetStringByStrRef(8344)+"</c>";//feedback will be
  SendMessageToPC(oTarget,sFeedback);//in english, while normally it would be in his language...
  SendMessageToPC(oCaster,sFeedback);
  DelayCommand(fDelay,ApplyEffectToObject(DURATION_TYPE_INSTANT,EffectVisualEffect(VFX_IMP_GLOBE_USE),oTarget));
@@ -601,7 +601,7 @@ effect eWorkaround;
   string sFeedback = GetStringByStrRef(8342);
   sFeedback = GetStringLeft(sFeedback,GetStringLength(sFeedback)-10);
   sFeedback = GetStringRight(sFeedback,GetStringLength(sFeedback)-10);
-  sFeedback = "<c???>"+GetName(oTarget)+"</c> <c??>"+sFeedback+" "+GetStringByStrRef(nResisted == 1 ? 8343 : 5353)+"</c>";
+  sFeedback = "<c\x9b\xfe\xfe>"+GetName(oTarget)+"</c> <c\xcd\x7f\xfe>"+sFeedback+" "+GetStringByStrRef(nResisted == 1 ? 8343 : 5353)+"</c>";
   SendMessageToPC(oTarget,sFeedback);
   SendMessageToPC(oCaster,sFeedback);
   }

--- a/src/nss/nw_s1_aurafirec.nss
+++ b/src/nss/nw_s1_aurafirec.nss
@@ -25,7 +25,7 @@ void main()
     //Declare major variables
     aoesDeclareMajorVariables();
     int nHD = GetHitDice(aoe.Creator);
-    int nDC = 10 + nHD/3;
+    int nDC = 7 + nHD/3;
     nHD = nHD/3+1;
     int nDamage;
     effect eDam;
@@ -41,14 +41,13 @@ void main()
             //Roll damage
             nDamage = d4(nHD);
             //Make a saving throw check
-            if(MySavingThrow(SAVING_THROW_FORT, oTarget, nHD, SAVING_THROW_TYPE_FIRE, aoe.Creator))
+            if(!MySavingThrow(SAVING_THROW_FORT, oTarget, nDC, SAVING_THROW_TYPE_FIRE, aoe.Creator))
             {
-                nDamage = nDamage / 2;
+                //Set the damage effect
+                eDam = EffectDamage(nDamage, DAMAGE_TYPE_FIRE);
+                ApplyEffectToObject(DURATION_TYPE_INSTANT, eVis, oTarget);
+                ApplyEffectToObject(DURATION_TYPE_INSTANT, eDam, oTarget);
             }
-            //Set the damage effect
-            eDam = EffectDamage(nDamage, DAMAGE_TYPE_FIRE);
-            ApplyEffectToObject(DURATION_TYPE_INSTANT, eVis, oTarget);
-            ApplyEffectToObject(DURATION_TYPE_INSTANT, eDam, oTarget);
         }
         //Get next target in spell area
         oTarget = GetNextInPersistentObject(aoe.AOE);

--- a/src/nss/nw_s1_auramenca.nss
+++ b/src/nss/nw_s1_auramenca.nss
@@ -29,6 +29,11 @@ void main()
 
     effect eLink = CreateDoomEffectsLink();
     eLink = SupernaturalEffect(eLink);
+    
+    if (GetLocalInt(OBJECT_SELF, "doomaura" + ObjectToString(oTarget)))
+    {
+        return;
+    }
 
     if(spellsIsTarget(oTarget, SPELL_TARGET_SELECTIVEHOSTILE, oCreator))
     {
@@ -40,5 +45,6 @@ void main()
             ApplyEffectToObject(DURATION_TYPE_INSTANT, eVis, oTarget);
             ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eLink, oTarget, TurnsToSeconds(nDuration));
         }
+        SetLocalInt(OBJECT_SELF, "doomaura" + ObjectToString(oTarget), 1);
     }
 }

--- a/src/nss/x2_s0_elecloop.nss
+++ b/src/nss/x2_s0_elecloop.nss
@@ -79,6 +79,7 @@ void main()
     {
         if (spellsIsTarget(oTarget, spell.TargetType, spell.Caster))
         {
+            spell.SavingThrow = SAVING_THROW_REFLEX;
             SignalEvent(oTarget, EventSpellCastAt(spell.Caster, spell.Id));
 
             //------------------------------------------------------------------
@@ -118,6 +119,7 @@ void main()
                 //--------------------------------------------------------------
                 if (nDamage > 0 && (nDamage == nPotential || GetHasFeat(FEAT_IMPROVED_EVASION,oTarget)))
                 {
+                    spell.SavingThrow = SAVING_THROW_WILL;
                     if(!MySavingThrow(spell.SavingThrow, oTarget, spell.DC, SAVING_THROW_TYPE_MIND_SPELLS, spell.Caster, fDelay))
                     {
                         DelayCommand(fDelay, ApplyEffectToObject(DURATION_TYPE_TEMPORARY,eStun,oTarget, RoundsToSeconds(1)));


### PR DESCRIPTION
Ghoul doom auras now only force each creature to roll once (rather than every time they enter the range).
Death messages shown in game no longer display Discord's bold formatting markers (double asterisk).
Henchmen that have hit their revival count should now be targetable when dead to allow players to cast Raise Dead on them.
The henchman death message now names the henchman that died.
Trade of Blades now grants Rested XP following its renovation into a pretty comfy looking place that serves drinks.
Moved a chest in the Hotenow Drow Building out from inside a cage.
Restored Fire Elemental aura to the modified version instead of CPP's wimpy thing that was completely pointless (save DC of 2)
The stunning portion of Gedlee's Electric Loop is now correctly a Will save.
Fix for some custom colour tokens related to dispelling that contained characters which become multibyte when passed through certain encodings being obliterated by some part of the workflow.
Fixed an oversight which might have caused more powerful items to drop in areas lower than they were intended to in very specific circumstances.