### PR TITLE
Fix maker bookcases and heroic shield area stickiness

### DIFF
--- a/src/git/ud_maker2.git.json
+++ b/src/git/ud_maker2.git.json
@@ -93168,6 +93168,21 @@
           "type": "int",
           "value": 1
         }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "clean_script"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "clean_maker2"
+        }
       }
     ]
   },

--- a/src/nss/area_cleanup.nss
+++ b/src/nss/area_cleanup.nss
@@ -167,5 +167,11 @@ void main()
         CleanupRandomSpawns(OBJECT_SELF, i);
      }
      
+     string sScript = GetLocalString(OBJECT_SELF, "clean_script");
+     if (sScript != "")
+     {
+         ExecuteScript(sScript, OBJECT_SELF);
+     }
+     
      SetLocalInt(OBJECT_SELF, "cleaned_time", SQLite_GetTimeStamp());
 }

--- a/src/nss/clean_maker2.nss
+++ b/src/nss/clean_maker2.nss
@@ -1,0 +1,71 @@
+#include "nwnx_object"
+
+void main()
+{
+    // Randomise the puzzle.
+    // Work out how many bookcases they are, if we haven't done it already.
+    // This could be hardcoded or done on init, but organisation dictates doing it here I guess?
+    int i;
+    if (!GetLocalInt(OBJECT_SELF, "num_bookcases_1"))
+    {
+        int j;
+        i = 1;
+        // Outer: rooms
+        while (1)
+        {
+            j = 1;
+            // Inner: bookcases in each room
+            while (1)
+            {
+                string sBookCase = "maker2_bookcase" + IntToString(i) + "_" + IntToString(j);
+                object oBookCase = GetObjectByTag(sBookCase);
+                if (!GetIsObjectValid(oBookCase))
+                {
+                    break;
+                }
+                SetUseableFlag(oBookCase, FALSE);
+                SetPlotFlag(oBookCase, TRUE);
+                NWNX_Object_SetPlaceableIsStatic(oBookCase, TRUE);
+                SetEventScript(oBookCase, EVENT_SCRIPT_PLACEABLE_ON_USED, "maker2_bookcase");
+                j++;
+            }
+            if (j == 1)
+            {
+                // This room doesn't actually exist as no bookcases were found in it
+                SetLocalInt(OBJECT_SELF, "num_bookcase_rooms", i-1);
+                break;
+            }
+            SetLocalInt(OBJECT_SELF, "num_bookcases_" + IntToString(i), j-1);
+            WriteTimestampedLogEntry("Bookcases: room " + IntToString(i) + " has " + IntToString(j-1) + " cases");
+            i++;
+        }
+    }
+    else
+    {
+        int nNumRooms = GetLocalInt(OBJECT_SELF, "num_bookcase_rooms");
+        // Revert old bookcases
+        for (i=1; i<=nNumRooms; i++)
+        {
+            object oBookCase = GetLocalObject(OBJECT_SELF, "active_bookcase_" + IntToString(i));
+            SetUseableFlag(oBookCase, FALSE);
+            NWNX_Object_SetPlaceableIsStatic(oBookCase, TRUE);
+            DeleteLocalInt(oBookCase, "active");
+        }
+    }
+    int nNumRooms = GetLocalInt(OBJECT_SELF, "num_bookcase_rooms");
+    int nActiveRoom = Random(nNumRooms) + 1;
+    WriteTimestampedLogEntry("Active bookcase: " + IntToString(nActiveRoom) + " of " + IntToString(nNumRooms));
+    for (i=1; i<=nNumRooms; i++)
+    {
+        int nNumBookCasesInThisRoom = GetLocalInt(OBJECT_SELF, "num_bookcases_" + IntToString(nNumRooms));
+        int nActiveCaseInThisRoom = Random(nNumBookCasesInThisRoom) + 1;
+        object oBookCase = GetObjectByTag("maker2_bookcase" + IntToString(i) + "_" + IntToString(nActiveCaseInThisRoom));
+        NWNX_Object_SetPlaceableIsStatic(oBookCase, FALSE);
+        SetUseableFlag(oBookCase, TRUE);
+        if (i == nActiveRoom)
+        {
+            SetLocalInt(oBookCase, "active", 1);
+        }
+        SetLocalObject(OBJECT_SELF, "active_bookcase_" + IntToString(i), oBookCase);
+    }
+}

--- a/src/nss/refresh_maker2.nss
+++ b/src/nss/refresh_maker2.nss
@@ -196,71 +196,7 @@ void main()
         oTest = GetNextObjectInArea(OBJECT_SELF);
     }
     
-    // Randomise the puzzle.
-    // Work out how many bookcases they are, if we haven't done it already.
-    // This could be hardcoded or done on init, but organisation dictates doing it here I guess?
-    if (!GetLocalInt(OBJECT_SELF, "num_bookcases_1"))
-    {
-        int j;
-        i = 1;
-        // Outer: rooms
-        while (1)
-        {
-            j = 1;
-            // Inner: bookcases in each room
-            while (1)
-            {
-                string sBookCase = "maker2_bookcase" + IntToString(i) + "_" + IntToString(j);
-                object oBookCase = GetObjectByTag(sBookCase);
-                if (!GetIsObjectValid(oBookCase))
-                {
-                    break;
-                }
-                SetUseableFlag(oBookCase, FALSE);
-                SetPlotFlag(oBookCase, TRUE);
-                NWNX_Object_SetPlaceableIsStatic(oBookCase, TRUE);
-                SetEventScript(oBookCase, EVENT_SCRIPT_PLACEABLE_ON_USED, "maker2_bookcase");
-                j++;
-            }
-            if (j == 1)
-            {
-                // This room doesn't actually exist as no bookcases were found in it
-                SetLocalInt(OBJECT_SELF, "num_bookcase_rooms", i-1);
-                break;
-            }
-            SetLocalInt(OBJECT_SELF, "num_bookcases_" + IntToString(i), j-1);
-            WriteTimestampedLogEntry("Bookcases: room " + IntToString(i) + " has " + IntToString(j-1) + " cases");
-            i++;
-        }
-    }
-    else
-    {
-        int nNumRooms = GetLocalInt(OBJECT_SELF, "num_bookcase_rooms");
-        // Revert old bookcases
-        for (i=1; i<=nNumRooms; i++)
-        {
-            object oBookCase = GetLocalObject(OBJECT_SELF, "active_bookcase_" + IntToString(i));
-            SetUseableFlag(oBookCase, FALSE);
-            NWNX_Object_SetPlaceableIsStatic(oBookCase, TRUE);
-            DeleteLocalInt(oBookCase, "active");
-        }
-    }
-    int nNumRooms = GetLocalInt(OBJECT_SELF, "num_bookcase_rooms");
-    int nActiveRoom = Random(nNumRooms) + 1;
-    WriteTimestampedLogEntry("Active bookcase: " + IntToString(nActiveRoom) + " of " + IntToString(nNumRooms));
-    for (i=1; i<=nNumRooms; i++)
-    {
-        int nNumBookCasesInThisRoom = GetLocalInt(OBJECT_SELF, "num_bookcases_" + IntToString(nNumRooms));
-        int nActiveCaseInThisRoom = Random(nNumBookCasesInThisRoom) + 1;
-        object oBookCase = GetObjectByTag("maker2_bookcase" + IntToString(i) + "_" + IntToString(nActiveCaseInThisRoom));
-        NWNX_Object_SetPlaceableIsStatic(oBookCase, FALSE);
-        SetUseableFlag(oBookCase, TRUE);
-        if (i == nActiveRoom)
-        {
-            SetLocalInt(oBookCase, "active", 1);
-        }
-        SetLocalObject(OBJECT_SELF, "active_bookcase_" + IntToString(i), oBookCase);
-    }
+    // Active bookcases are done in clean_maker2 now
     
     // Randomise the ten arcane words onto the numbers
     json jWords = JsonArray();

--- a/src/nss/x3_s2_pdk_shield.nss
+++ b/src/nss/x3_s2_pdk_shield.nss
@@ -173,7 +173,7 @@ void main()
             if (GetLocalInt(oCreator, "pdk_shield_diffarea") >= 30)
             {
                 sReason = "Your Heroic Shield on " + GetName(OBJECT_SELF) + " ended because they have been in another area for too long.";
-                DeleteLocalInt(OBJECT_SELF, "pdk_shield_diffarea");
+                DeleteLocalInt(oCreator, "pdk_shield_diffarea");
                 bRemove = 1;
             }
             else
@@ -184,7 +184,7 @@ void main()
         }
         else
         {
-            DeleteLocalInt(OBJECT_SELF, "pdk_shield_diffarea");
+            DeleteLocalInt(oCreator, "pdk_shield_diffarea");
         }
         
         if (bRemove)


### PR DESCRIPTION
Tiny PR to add cleanup scripts (also run on init, which is super useful for this!). Tested and it seemed okay.

Fixed the Isle of the Maker bookcases not being usable until reentering the area.
Fixed Heroic Shield being cancelled after 30 seconds of total time in different areas (it was intended to require 30 seconds of consecutive time in different areas)
